### PR TITLE
Fix python package build

### DIFF
--- a/build_tools/apply_patches.sh
+++ b/build_tools/apply_patches.sh
@@ -42,5 +42,8 @@ apply_patch ROCR-Runtime ROCR-Runtime-intree-build.patch
 stash_changes HIPIFY
 apply_patch HIPIFY hipify-install-headers-in-include-hipify.patch
 
+stash_changes rocm_smi_lib
+apply_patch rocm_smi_lib rocm_smi_lib-use-cmake-generator-expr-for-target-out-path-when-stripping.patch
+
 stash_changes rccl
 apply_patch rccl rccl-overwrite-generated-files.patch

--- a/patches/rocm_smi_lib-use-cmake-generator-expr-for-target-out-path-when-stripping.patch
+++ b/patches/rocm_smi_lib-use-cmake-generator-expr-for-target-out-path-when-stripping.patch
@@ -1,0 +1,26 @@
+diff --git a/oam/CMakeLists.txt b/oam/CMakeLists.txt
+index 6927d24..3718a64 100644
+--- a/oam/CMakeLists.txt
++++ b/oam/CMakeLists.txt
+@@ -87,7 +87,7 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL Release)
+     if(${BUILD_SHARED_LIBS}) #striping only for .so
+         add_custom_command(
+              TARGET ${OAM_TARGET}
+-             POST_BUILD COMMAND ${CMAKE_STRIP} lib${OAM_TARGET}.so)
++             POST_BUILD COMMAND ${CMAKE_STRIP} "$<TARGET_FILE:${OAM_TARGET}>")
+     endif()
+ endif ()
+ 
+diff --git a/rocm_smi/CMakeLists.txt b/rocm_smi/CMakeLists.txt
+index 645e598..0b67549 100755
+--- a/rocm_smi/CMakeLists.txt
++++ b/rocm_smi/CMakeLists.txt
+@@ -109,7 +109,7 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL Release)
+   if(${BUILD_SHARED_LIBS}) #stripping only for .so
+     add_custom_command(
+           TARGET ${ROCM_SMI_TARGET}
+-          POST_BUILD COMMAND ${CMAKE_STRIP} lib${ROCM_SMI_TARGET}.so.${SO_VERSION_STRING})
++          POST_BUILD COMMAND ${CMAKE_STRIP} "$<TARGET_FILE:${ROCM_SMI_TARGET}>")
+   endif()
+ endif ()
+ 

--- a/python_projects/runtime/setup.py
+++ b/python_projects/runtime/setup.py
@@ -34,12 +34,12 @@ SOURCE_DIR = SETUPPY_DIR.parent.parent
 # Note that setuptools always builds into a "build" directory that
 # is a sibling of setup.py, so we just colonize a sub-directory of that
 # by default.
-CMAKE_BUILD_DIR = os.getenv(
+CMAKE_BUILD_DIR = Path(os.getenv(
     "THEROCK_CMAKE_BUILD_DIR", SETUPPY_DIR / "build" / "cmake-build"
-)
-CMAKE_INSTALL_DIR = os.getenv(
+))
+CMAKE_INSTALL_DIR = Path(os.getenv(
     "THEROCK_CMAKE_INSTALL_DIR", SETUPPY_DIR / "build" / "dist-install"
-)
+))
 
 with open(SETUPPY_DIR / "README.md", "rt") as f:
     README = f.read()
@@ -100,7 +100,6 @@ print("Found packages:", packages)
 CMAKE_INSTALL_DIR.mkdir(parents=True, exist_ok=True)
 (CMAKE_INSTALL_DIR / "__init__.py").touch()
 CMAKE_BUILD_DIR.mkdir(parents=True, exist_ok=True)
-
 # In order to reliably package the built files, it is best to run the build
 # prior to setup. All built artifacts go into the _therock top level
 # package so that source and built trees are distinct.


### PR DESCRIPTION
Make rocm_smi compatible with CMAKE_PLATFORM_NO_VERSIONED_SONAME by using CMake generator expressions for target library output path.