### PR TITLE
Add a background script to periodically report top background processes.

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -75,7 +75,9 @@ jobs:
           cmake -B build -GNinja . \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DTHEROCK_PACKAGE_VERSION="${package_version}"
+          ./build_tools/watch_top_processes.sh &
           cmake --build build
+          kill %1
 
       # - name: Build Tarballs
       #   run: |

--- a/build_tools/watch_top_processes.sh
+++ b/build_tools/watch_top_processes.sh
@@ -5,7 +5,7 @@
 function cycle() {
   echo ""
   echo ":::: TOP PROCESSES $(date) ::::"
-  ps aux | sort -nrk 3,3 | head -n 5
+  ps --no-headers aux | sort -nrk 3,3 | head -n 5 | cut -c -256
   echo ""
   echo ""
 }

--- a/build_tools/watch_top_processes.sh
+++ b/build_tools/watch_top_processes.sh
@@ -2,10 +2,18 @@
 # Reports top processes periodically. Meant to be run in the background before
 # starting a build with high latency tasks so that some progress can be seen.
 
-while true; do
+function cycle() {
   echo ""
   echo ":::: TOP PROCESSES $(date) ::::"
   ps aux | sort -nrk 3,3 | head -n 5
-  sleep 30
   echo ""
+  echo ""
+}
+
+while true; do
+  # Capture content and print in one write to attempt to avoid tearing on
+  # rapidly moving terminals.
+  report="$(cycle)"
+  echo "$report" 1>&2
+  sleep 30
 done

--- a/build_tools/watch_top_processes.sh
+++ b/build_tools/watch_top_processes.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Reports top processes periodically. Meant to be run in the background before
+# starting a build with high latency tasks so that some progress can be seen.
+
+while true; do
+  echo ""
+  echo ":::: TOP PROCESSES $(date) ::::"
+  ps aux | sort -nrk 3,3 | head -n 5
+  sleep 30
+  echo ""
+done


### PR DESCRIPTION
The ROCM build includes a fair number of multi-minute link steps, etc and this can be a blackhole when looking at CI logs. Add a script that periodically reports.