### PR TITLE
Extend target selection logic.

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -74,6 +74,7 @@ jobs:
           # Build.
           cmake -B build -GNinja . \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu \
             -DTHEROCK_PACKAGE_VERSION="${package_version}"
           ./build_tools/watch_top_processes.sh &
           cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ set(THEROCK_AMDGPU_FAMILIES "" CACHE STRING "AMDGPU target families to build for
 set(THEROCK_AMDGPU_TARGETS "" CACHE STRING "AMDGPU targets to build for")
 set(THEROCK_AMDGPU_DIST_BUNDLE_NAME "" CACHE STRING "Distribution bundle name for AMDGPU packages")
 
-therock_validate_amdbpu_targets()
+therock_validate_amdgpu_targets()
 
 ################################################################################
 # Global setup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ cmake_policy(SET CMP0135 NEW)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CMakeDependentOption)
 include(ExternalProject)
+include(therock_amdgpu_targets)
 include(therock_subproject)
 include(therock_job_pools)
 
@@ -44,10 +45,32 @@ endif()
 set(ROCM_MAJOR_VERSION 6)
 set(ROCM_MINOR_VERSION 3)
 set(ROCM_PATCH_VERSION 1)
-# set(AMDGPU_TARGETS "gfx90a gfx940 gfx942 gfx1100" CACHE STRING "AMDGPU Targets")
-# TODO: Shard jobs by gfx family and have better ergonomics for multiple family
-# specific packages.
-set(AMDGPU_TARGETS "gfx1100" CACHE STRING "AMDGPU Targets")
+
+################################################################################
+# GPU target selection
+#
+# GPU target selection can be done by specifying one of THEROCK_AMDGPU_FAMILIES
+# or THEROCK_AMDGPU_TARGETS. Most targets are bundled into families that include
+# several related targets.
+#
+# If exactly one family or target is specified, then that is also taken to be
+# the THEROCK_AMDGPU_DIST_BUNDLE_NAME, if omitted (this is the identifier
+# embedded into package names). If more than one family or discrete target is
+# specified, then the bundle name must be specified manually.
+#
+# Once cache variable validation is done, THEROCK_AMDGPU_TARGETS will be the
+# fully expanded list of targets (as a local variable). For convenience and
+# because some parts of the tree use a space separated list,
+# THEROCK_AMDGPU_TARGETS_SPACES will also be set.
+#
+# See therock_amdgpu_targets.cmake for further details.
+################################################################################
+
+set(THEROCK_AMDGPU_FAMILIES "" CACHE STRING "AMDGPU target families to build for")
+set(THEROCK_AMDGPU_TARGETS "" CACHE STRING "AMDGPU targets to build for")
+set(THEROCK_AMDGPU_DIST_BUNDLE_NAME "" CACHE STRING "Distribution bundle name for AMDGPU packages")
+
+therock_validate_amdbpu_targets()
 
 ################################################################################
 # Global setup

--- a/build_tools/watch_top_processes.sh
+++ b/build_tools/watch_top_processes.sh
@@ -5,7 +5,7 @@
 function cycle() {
   echo ""
   echo ":::: TOP PROCESSES $(date) ::::"
-  ps --no-headers aux | sort -nrk 3,3 | head -n 5 | cut -c -256
+  ps --no-headers aux | sort -nrk 3,3 | head -n 5 | cut -c -768
   echo ""
   echo ""
 }

--- a/build_tools/watch_top_processes.sh
+++ b/build_tools/watch_top_processes.sh
@@ -5,7 +5,7 @@
 function cycle() {
   echo ""
   echo ":::: TOP PROCESSES $(date) ::::"
-  ps --no-headers aux | sort -nrk 3,3 | head -n 5 | cut -c -768
+  ps --no-headers aux | sort -nrk 3,3 | head -n 5
   echo ""
   echo ""
 }

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -53,8 +53,8 @@ therock_add_amdgpu_target(gfx1102 "AMD RX 7700S/Framework Laptop 16" FAMILY igpu
 therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu)
 
 # gfx115X family
-therock_add_amdgpu_target(gfx1150 "AMD Strix Point iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu)
-therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu)
+therock_add_amdgpu_target(gfx1150 "AMD Strix Point iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu)
+therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx115X-all gfx115X-igpu)
 
 
 # Validates and normalizes AMDGPU target selection cache variables.

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -1,0 +1,131 @@
+# Target metadata is maintained as global properties:
+#   THEROCK_AMDGPU_TARGETS: List of gfx target names
+#   THEROCK_AMDGPU_TARGET_FAMILIES: List of target families (may contain duplicates)
+#   THEROCK_AMDGPU_TARGET_NAME_{gfx_target}: Product name of the gfx target
+#   THEROCK_AMDGPU_TARGET_FAMILY_{family}: List of gfx targets within a named
+#     family
+set_property(GLOBAL PROPERTY THEROCK_AMDGPU_TARGETS)
+
+function(therock_add_amdgpu_target gfx_target product_name)
+  cmake_parse_arguments(PARSE_ARGV 2 ARG
+    ""
+    ""
+    "FAMILY"
+  )
+
+  get_property(_targets GLOBAL PROPERTY THEROCK_AMDGPU_TARGETS)
+  if("${gfx_target}" IN_LIST _targets)
+    message(FATAL_ERROR "AMDGPU target ${gfx_target} already defined")
+  endif()
+  set_property(GLOBAL APPEND PROPERTY THEROCK_AMDGPU_TARGETS "${gfx_target}")
+  set_property(GLOBAL PROPERTY "THEROCK_AMDGPU_TARGET_NAME_${gfx_target}" "${product_name}")
+  foreach(_family ${ARG_FAMILY})
+    set_property(GLOBAL APPEND PROPERTY THEROCK_AMDGPU_TARGET_FAMILIES "${_family}")
+    set_property(GLOBAL APPEND PROPERTY "THEROCK_AMDGPU_TARGET_FAMILY_${_family}" "${gfx_target}")
+  endforeach()
+endfunction()
+
+# gfx90X family
+therock_add_amdgpu_target(gfx906 "Radeon VII / MI50 CDNA" FAMILY dgpu-all gfx90X-all gfx90X-dgpu gfx90X-dcgpu)
+therock_add_amdgpu_target(gfx908 "MI100 CDNA" FAMILY gfx90X-all dcgpu-all gfx90X-dcgpu)
+therock_add_amdgpu_target(gfx90a "MI210/250 CDNA" FAMILY gfx90X-all dcgpu-all gfx90X-dcgpu)
+
+# gfx94X family
+therock_add_amdgpu_target(gfx940 "MI300A/MI300X CDNA" FAMILY dcgpu-all gfx94X-all gfx94X-dcgpu)
+therock_add_amdgpu_target(gfx941 "MI300A/MI300X CDNA" FAMILY dcgpu-all gfx94X-all gfx94X-dcgpu)
+therock_add_amdgpu_target(gfx942 "MI300A/MI300X CDNA" FAMILY dcgpu-all gfx94X-all gfx94X-dcgpu)
+
+# gfx101X family
+therock_add_amdgpu_target(gfx1010 "AMD RX 5700" FAMILY dgpu-all gfx101X-all gfx101X-dgpu)
+therock_add_amdgpu_target(gfx1011 "AMD Radeon Pro V520" FAMILY dgpu-all gfx101X-all gfx101X-dgpu)
+therock_add_amdgpu_target(gfx1012 "AMD RX 5500" FAMILY dgpu-all gfx101X-all gfx101X-dgpu)
+
+# gfx103X family
+therock_add_amdgpu_target(gfx1030 "AMD RX 6800 / XT" FAMILY dgpu-all gfx103X-all gfx103X-dgpu)
+therock_add_amdgpu_target(gfx1032 "AMD RX 6600" FAMILY dgpu-all gfx103X-all gfx103X-dgpu)
+therock_add_amdgpu_target(gfx1035 "AMD Radeon 680M Laptop iGPU" igpu-all FAMILY gfx103X-all gfx103X-igpu)
+therock_add_amdgpu_target(gfx1036 "AMD Raphael iGPU" FAMILY igpu-all gfx103X-all gfx103X-igpu)
+
+# gfx110X family
+therock_add_amdgpu_target(gfx1100 "AMD RX 7900 XTX" FAMILY dgpu-all gfx110X-all gfx110X-dgpu)
+therock_add_amdgpu_target(gfx1101 "AMD RX 7800 XT" FAMILY dgpu-all gfx110X-all gfx110X-dgpu)
+therock_add_amdgpu_target(gfx1102 "AMD RX 7700S/Framework Laptop 16" FAMILY igpu-all gfx110X-all gfx110X-igpu)
+therock_add_amdgpu_target(gfx1103 "AMD Radeon 780M Laptop iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu)
+
+# gfx115X family
+therock_add_amdgpu_target(gfx1150 "AMD Strix Point iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu)
+therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx110X-all gfx110X-igpu)
+
+
+# Validates and normalizes AMDGPU target selection cache variables.
+function(therock_validate_amdbpu_targets)
+  message(STATUS "Configured AMDGPU Targets:")
+  string(APPEND CMAKE_MESSAGE_INDENT "  ")
+  set(_expanded_targets)
+  set(_explicit_selections)
+  get_property(_available_families GLOBAL PROPERTY THEROCK_AMDGPU_TARGET_FAMILIES)
+  list(REMOVE_DUPLICATES _available_families)
+  get_property(_available_targets GLOBAL PROPERTY THEROCK_AMDGPU_TARGETS)
+  # Expand families.
+  foreach(_family ${THEROCK_AMDGPU_FAMILIES})
+    list(APPEND _explicit_selections "${_family}")
+    if(NOT "${_family}" IN_LIST _available_families)
+      string(JOIN " " _families_pretty ${_available_families})
+      message(FATAL_ERROR
+        "THEROCK_AMDGPU_FAMILIES value '${_family}' unknown. Available: "
+        ${_families_pretty})
+    endif()
+    get_property(_family_targets GLOBAL PROPERTY "THEROCK_AMDGPU_TARGET_FAMILY_${_family}")
+    list(APPEND _expanded_targets ${_family_targets})
+  endforeach()
+
+  # And expand loose targets.
+  foreach(_target ${THEROCK_AMDGPU_TARGETS})
+    list(APPEND _explicit_selections "${_target}")
+    list(APPEND _expanded_targets ${_target})
+  endforeach()
+
+  # Validate targets.
+  list(REMOVE_DUPLICATES _expanded_targets)
+  foreach(_target ${_expanded_targets})
+    string(JOIN " " _targets_pretty ${_available_targets})
+    if(NOT "${_target}" IN_LIST _available_targets)
+      message(FATAL_ERROR "Unknown AMDGPU target '${_target}'. Available: "
+        ${_targets_pretty})
+    endif()
+    get_property(_target_name GLOBAL PROPERTY "THEROCK_AMDGPU_TARGET_NAME_${_target}")
+    message(STATUS "* ${_target} : ${_target_name}")
+  endforeach()
+
+  # Must have a target.
+  if(NOT _expanded_targets)
+    message(FATAL_ERROR
+      "No AMDGPU target selected: make a selection via THEROCK_AMDGPU_FAMILIES "
+      "or THEROCK_AMDGPU_TARGETS."
+    )
+  endif()
+  # Export to parent scope.
+  set(THEROCK_AMDGPU_TARGETS "${_expanded_targets}" PARENT_SCOPE)
+  string(JOIN " " _expanded_targets_spaces ${_expanded_targets})
+  set(THEROCK_AMDGPU_TARGETS_SPACES "${_expanded_targets_spaces}" PARENT_SCOPE)
+
+  if(NOT THEROCK_AMDGPU_DIST_BUNDLE_NAME)
+    list(LENGTH _explicit_selections _explicit_count)
+    if(_explicit_count GREATER "1")
+      message(FATAL_ERROR
+        "More than one AMDGPU target bundle selected (${_explicit_selections}): "
+        "THEROCK_AMDGPU_DIST_BUNDLE_NAME must be set explicitly since it cannot "
+        "be inferred."
+      )
+    endif()
+    set(THEROCK_AMDGPU_DIST_BUNDLE_NAME "${_explicit_selections}" PARENT_SCOPE)
+    message(STATUS "* Dist bundle: ${_explicit_selections}")
+  else()
+    message(STATUS "* Dist bundle: ${THEROCK_AMDGPU_DIST_BUNDLE_NAME}")
+  endif()
+endfunction()
+
+function(therock_get_amdgpu_target_name out_var gfx_target)
+  get_property(_name GLOBAL PROPERTY "THEROCK_AMDGPU_TARGET_NAME_${gfx_target}")
+  set("${out_var}" "${_name}" PARENT_SCOPE)
+endfunction()

--- a/cmake/therock_amdgpu_targets.cmake
+++ b/cmake/therock_amdgpu_targets.cmake
@@ -58,7 +58,7 @@ therock_add_amdgpu_target(gfx1151 "AMD Strix Halo iGPU" FAMILY igpu-all gfx110X-
 
 
 # Validates and normalizes AMDGPU target selection cache variables.
-function(therock_validate_amdbpu_targets)
+function(therock_validate_amdgpu_targets)
   message(STATUS "Configured AMDGPU Targets:")
   string(APPEND CMAKE_MESSAGE_INDENT "  ")
   set(_expanded_targets)

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -761,7 +761,7 @@ function(_therock_cmake_subproject_setup_toolchain compiler_toolchain toolchain_
     message(STATUS "CMAKE_C_COMPILER = ${AMD_LLVM_C_COMPILER}")
     message(STATUS "CMAKE_CXX_COMPILER = ${AMD_LLVM_CXX_COMPILER}")
     message(STATUS "CMAKE_LINKER = ${AMD_LLVM_LINKER}")
-    message(STATUS "AMDGPU_TARGETS = ${_amdgpu_targets_spaces}")
+    message(STATUS "AMDGPU_TARGETS = ${THEROCK_AMDGPU_TARGETS_SPACES}")
   else()
     message(FATAL_ERROR "Unsupported COMPILER_TOOLCHAIN = ${compiler_toolchain} (supported: 'amd-llvm' or none)")
   endif()

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -20,7 +20,6 @@ set_property(GLOBAL PROPERTY THEROCK_DEFAULT_CMAKE_VARS
   THEROCK_SOURCE_DIR
   THEROCK_BINARY_DIR
   ROCM_GIT_DIR
-  AMDGPU_TARGETS
 )
 
 set_property(GLOBAL PROPERTY THEROCK_SUBPROJECT_COMPILE_COMMANDS_FILES)
@@ -755,12 +754,14 @@ function(_therock_cmake_subproject_setup_toolchain compiler_toolchain toolchain_
     string(APPEND _toolchain_contents "set(CMAKE_C_COMPILER @AMD_LLVM_C_COMPILER@)\n")
     string(APPEND _toolchain_contents "set(CMAKE_CXX_COMPILER @AMD_LLVM_CXX_COMPILER@)\n")
     string(APPEND _toolchain_contents "set(CMAKE_LINKER @AMD_LLVM_LINKER@)\n")
+    string(APPEND _toolchain_contents "set(AMDGPU_TARGETS @THEROCK_AMDGPU_TARGETS@ CACHE STRING \"From super-project\" FORCE)\n")
 
     message(STATUS "Compiler toolchain ${compiler_toolchain}:")
     string(APPEND CMAKE_MESSAGE_INDENT "  ")
     message(STATUS "CMAKE_C_COMPILER = ${AMD_LLVM_C_COMPILER}")
     message(STATUS "CMAKE_CXX_COMPILER = ${AMD_LLVM_CXX_COMPILER}")
     message(STATUS "CMAKE_LINKER = ${AMD_LLVM_LINKER}")
+    message(STATUS "AMDGPU_TARGETS = ${_amdgpu_targets_spaces}")
   else()
     message(FATAL_ERROR "Unsupported COMPILER_TOOLCHAIN = ${compiler_toolchain} (supported: 'amd-llvm' or none)")
   endif()


### PR DESCRIPTION
* Adds a target database, encoded as CMake properties.
* Accepts user target selection flags of:
  * -DTHEROCK_AMDGPU_FAMILIES=...
  * -DTHEROCK_AMDGPU_TARGETS=...
* Defines a -DTHEROCK_AMDGPU_DIST_BUNDLE_NAME for a next step of building arch-packages.