### PR TITLE
Skip dlopen test on Windows for now.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,11 +117,17 @@ endif()
 # # Testing
 # ################################################################################
 
-add_executable(
-  dlopen-hip
-  tests/dlopen-hip.c
-)
-target_link_libraries(dlopen-hip dl)
+if(NOT WIN32)
+  add_executable(
+    dlopen-hip
+    tests/dlopen-hip.c
+  )
+  target_link_libraries(dlopen-hip dl)
+else()
+  # TODO: Test that is compatible with Windows (LoadLibraryA instead of dlopen)
+  #   then add instructions in the README to run with a command like
+  #   `./build/dlopen-hip install/amdhip64.dll`
+endif()
 
 
 ################################################################################


### PR DESCRIPTION
Logs:
```
[build] [15/123   4% :: 0.278] Building C object CMakeFiles\dlopen-hip.dir\tests\dlopen-hip.c.obj
[build] FAILED: CMakeFiles/dlopen-hip.dir/tests/dlopen-hip.c.obj
[build] ccache C:\PROGRA~2\MICROS~2\2022\BUILDT~1\VC\Tools\MSVC\1442~1.344\bin\Hostx64\x64\cl.exe  /nologo   /DWIN32 /D_WINDOWS /Zi /O2 /Ob1 /DNDEBUG -MD /showIncludes /FoCMakeFiles\dlopen-hip.dir\tests\dlopen-hip.c.obj /FdCMakeFiles\dlopen-hip.dir\ /FS -c D:\projects\TheRock\tests\dlopen-hip.c
[build] D:\projects\TheRock\tests\dlopen-hip.c(1): fatal error C1083: Cannot open include file: 'dlfcn.h': No such file or directory
```

The https://github.com/nod-ai/TheRock/blob/main/tests/dlopen-hip.c file is using a Unix header for `dlopen` of a shared object file. On Windows, an API like https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibrarya is typically used to open a DLL instead.