### PR TITLE
Add automation for producing artifact slices.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CMakeDependentOption)
 include(ExternalProject)
 include(therock_amdgpu_targets)
+include(therock_artifacts)
 include(therock_subproject)
 include(therock_job_pools)
 
@@ -83,14 +84,9 @@ configure_file(HIP_VERSION.in ${ROCM_GIT_DIR}/HIP/VERSION)
 
 set(STAGING_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/staging_install")
 
-################################################################################
-# External project setup
-################################################################################
-
 # On some distributions, this will install to lib64. We would like
 # consistency in built packages, so hard-code it.
 set(CMAKE_INSTALL_LIBDIR "lib")
-
 
 if(CMAKE_C_VISIBILITY_PRESET)
   list(APPEND DEFAULT_CMAKE_ARGS ${CMAKE_C_VISIBILITY_PRESET})
@@ -98,6 +94,11 @@ endif()
 if(CMAKE_CXX_VISIBILITY_PRESET)
   list(APPEND DEFAULT_CMAKE_ARGS ${CMAKE_CXX_VISIBILITY_PRESET})
 endif()
+
+
+################################################################################
+# External project setup
+################################################################################
 
 # Add subdirectories in dependency DAG order (which happens to be semi-alpha:
 # don't be fooled).
@@ -112,6 +113,7 @@ endif()
 if(THEROCK_ENABLE_ML_FRAMEWORKS)
   add_subdirectory(ml-frameworks)
 endif()
+
 
 # ################################################################################
 # # Testing

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -81,3 +81,25 @@ therock_cmake_subproject_glob_c_sources(rocm-half
     include
 )
 therock_cmake_subproject_activate(rocm-half)
+
+
+################################################################################
+# Artifacts
+################################################################################
+
+therock_provide_artifact(base
+  TARGET_NEUTRAL
+  DESCRIPTOR artifact.toml
+  COMPONENTS
+    run
+    dev
+    dbg
+    doc
+    test
+  SUBPROJECT_DEPS
+    rocm-cmake
+    rocm-core
+    rocm_smi_lib
+    rocprofiler-register
+    rocm-half
+)

--- a/base/artifact.toml
+++ b/base/artifact.toml
@@ -1,0 +1,35 @@
+# half
+[components.dev."base/half/stage"]
+[components.doc."base/half/stage"]
+
+# rocm_smi_lib
+[components.dev."base/rocm_smi_lib/stage"]
+[components.doc."base/rocm_smi_lib/stage"]
+[components.run."base/rocm_smi_lib/stage"]
+include = [
+  "bin/**",
+  "libexec/**",
+]
+
+# rocm-cmake
+[components.dev."base/rocm-cmake/stage"]
+[components.doc."base/rocm-cmake/stage"]
+
+# rocm-core
+[components.dev."base/rocm-core/stage"]
+include = "include/**"
+[components.doc."base/rocm-core/stage"]
+[components.run."base/rocm-core/stage"]
+include = [
+  "libexec/**",
+  "lib/rocmmod",
+]
+
+# rocprofiler-register
+[components.dev."base/rocprofiler-register/stage"]
+[components.doc."base/rocprofiler-register/stage"]
+[components.run."base/rocprofiler-register/stage"]
+[components.test."base/rocprofiler-register/stage"]
+include = [
+  "share/rocprofiler-register/tests/**",
+]

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -22,6 +22,71 @@ import shutil
 import sys
 
 
+class ComponentDefaults:
+    """Defaults for to apply to artifact merging by component name."""
+
+    def __init__(self, includes=(), excludes=()):
+        self.includes = list(includes)
+        self.excludes = list(excludes)
+
+
+COMPONENT_DEFAULTS: dict[str, ComponentDefaults] = {
+    # Debug components collect all platform specific dbg file patterns.
+    "dbg": ComponentDefaults(
+        includes=[
+            "**/*.dbg",
+        ],
+    ),
+    # Run components by default include all name-based executables in the tree.
+    # Descriptors should explicitly include bin/ directories and other places
+    # that include runnable artifacts (Python files, etc).
+    "run": ComponentDefaults(
+        includes=[
+            # Must be synced with "dev" excludes.
+            "**/*.exe",
+            "**/*.dll",
+            "**/*.dylib",
+            "**/*.dylib.*",
+            "**/*.so",
+            "**/*.so.*",
+            "**/share/modulefiles/**",
+        ],
+        excludes=[
+            "**/*.a",
+            "**/*.dbg",
+            "**/cmake/**",
+        ],
+    ),
+    # Dev components include all static library based file patterns and
+    # exclude file name patterns implicitly included for "run".
+    # Descriptors should explicitly include header file any package file
+    # sub-trees that do not have an explicit "cmake" path component in
+    # them.
+    "dev": ComponentDefaults(
+        includes=[
+            "**/*.a",
+            "**/cmake/**",
+            "**/include/**",
+        ],
+        excludes=[
+            # Must be synced with "run" includes.
+            "**/*.exe",
+            "**/*.dll",
+            "**/*.dylib",
+            "**/*.dylib.*",
+            "**/*.so",
+            "**/*.so.*",
+            "**/share/modulefiles/**",
+        ],
+    ),
+    "doc": ComponentDefaults(
+        includes=[
+            "**/share/doc/**",
+        ],
+    ),
+}
+
+
 class RecursiveGlobPattern:
     def __init__(self, glob: str):
         self.glob = glob
@@ -91,6 +156,77 @@ class PatternMatcher:
             if not excluded:
                 yield match_path, direntry
 
+    def copy_to(
+        self,
+        *,
+        destdir: Path,
+        destprefix: str = "",
+        verbose: bool = False,
+        always_copy: bool = False,
+        remove_dest: bool = True,
+    ):
+        if remove_dest and destdir.exists():
+            if verbose:
+                print(f"rmtree {destdir}", file=sys.stderr)
+            shutil.rmtree(destdir)
+        destdir.mkdir(parents=True, exist_ok=True)
+
+        for relpath, direntry in self.matches():
+            try:
+                destpath = destdir / PurePosixPath(destprefix + relpath)
+                if direntry.is_dir(follow_symlinks=False):
+                    # Directory.
+                    if verbose:
+                        print(f"mkdir {destpath}", file=sys.stderr, end="")
+                    destpath.mkdir(parents=True, exist_ok=True)
+                elif direntry.is_symlink():
+                    # Symlink.
+                    if not remove_dest and destpath.exists(follow_symlinks=False):
+                        os.unlink(destpath)
+                    targetpath = os.readlink(direntry.path)
+                    if verbose:
+                        print(
+                            f"symlink {targetpath} -> {destpath}",
+                            file=sys.stderr,
+                            end="",
+                        )
+                    destpath.parent.mkdir(parents=True, exist_ok=True)
+                    os.symlink(targetpath, destpath)
+                else:
+                    # Regular file.
+                    if not remove_dest and destpath.exists(follow_symlinks=False):
+                        os.unlink(destpath)
+                    destpath.parent.mkdir(parents=True, exist_ok=True)
+                    linked_file = False
+                    if not always_copy:
+                        # Attempt to link
+                        try:
+                            if verbose:
+                                print(
+                                    f"hardlink {direntry.path} -> {destpath}",
+                                    file=sys.stderr,
+                                    end="",
+                                )
+                            os.link(direntry.path, destpath, follow_symlinks=False)
+                            linked_file = True
+                        except OSError:
+                            if verbose:
+                                print(
+                                    " (falling back to copy) ", file=sys.stderr, end=""
+                                )
+                    if not linked_file:
+                        # Make a copy instead.
+                        if verbose:
+                            print(
+                                f"copy {direntry.path} -> {destpath}",
+                                file=sys.stderr,
+                                end="",
+                            )
+                        shutil.copy2(direntry.path, destpath, follow_symlinks=False)
+            finally:
+                if verbose:
+                    print("", file=sys.stderr)
+
 
 def do_list(args: argparse.Namespace, pm: PatternMatcher):
     for relpath, direntry in pm.matches():
@@ -100,61 +236,106 @@ def do_list(args: argparse.Namespace, pm: PatternMatcher):
 def do_copy(args: argparse.Namespace, pm: PatternMatcher):
     verbose = args.verbose
     destdir: Path = args.dest_dir
-    if args.remove_dest and destdir.exists():
-        if verbose:
-            print(f"rmtree {destdir}", file=sys.stderr)
-        shutil.rmtree(destdir)
-    destdir.mkdir(parents=True, exist_ok=True)
-    for relpath, direntry in pm.matches():
-        try:
-            destpath = destdir / PurePosixPath(relpath)
-            if direntry.is_dir(follow_symlinks=False):
-                # Directory.
-                if verbose:
-                    print(f"mkdir {destpath}", file=sys.stderr, end="")
-                destpath.mkdir(parents=True, exist_ok=True)
-            elif direntry.is_symlink():
-                # Symlink.
-                if not args.remove_dest and destpath.exists(follow_symlinks=False):
-                    os.unlink(destpath)
-                targetpath = os.readlink(direntry.path)
-                if verbose:
-                    print(
-                        f"symlink {targetpath} -> {destpath}", file=sys.stderr, end=""
-                    )
-                os.symlink(targetpath, destpath)
-            else:
-                # Regular file.
-                if not args.remove_dest and destpath.exists(follow_symlinks=False):
-                    os.unlink(destpath)
-                destpath.parent.mkdir(parents=True, exist_ok=True)
-                linked_file = False
-                if not args.always_copy:
-                    # Attempt to link
-                    try:
-                        if verbose:
-                            print(
-                                f"hardlink {direntry.path} -> {destpath}",
-                                file=sys.stderr,
-                                end="",
-                            )
-                        os.link(direntry.path, destpath, follow_symlinks=False)
-                        linked_file = True
-                    except OSError:
-                        if verbose:
-                            print(" (falling back to copy) ", file=sys.stderr, end="")
-                if not linked_file:
-                    # Make a copy instead.
-                    if verbose:
-                        print(
-                            f"copy {direntry.path} -> {destpath}",
-                            file=sys.stderr,
-                            end="",
-                        )
-                    shutil.copy2(direntry.path, destpath, follow_symlinks=False)
-        finally:
-            if verbose:
-                print("", file=sys.stderr)
+    pm.copy_to(
+        destdir=destdir,
+        verbose=verbose,
+        always_copy=args.always_copy,
+        remove_dest=args.remove_dest,
+    )
+
+
+def do_artifact(args):
+    """Produces an 'artifact directory', which is a slice of installed stage/
+    directories, split into components (i.e. run, dev, dbg, doc, test).
+
+    The primary input is the artifact.toml file, which defines records like:
+
+        "components" : dict of covered component names
+            "{component_name}": dict of build/ relative paths to materialize
+                "{stage_directory}":
+                    "include": str or list[str] of include patterns
+                    "exclude": str or list[str] of exclude patterns
+                    "optional": if true and the directory does not exist, it
+                      is not an error. Use for optionally built projects
+
+    Most sections can typically be blank because by default they use
+    component specific include/exclude patterns (see `COMPONENT_DEFAULTS` above)
+    that cover most common cases. Local deviations must be added explicitly
+    in the descriptor.
+
+    This is called once per component and will create a directory for that
+    component.
+    """
+    descriptor = load_toml_file(args.descriptor) or {}
+    component_name = args.component
+    # Set up output dir.
+    output_dir: Path = args.output_dir
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Get metadata for the component we are merging.
+    try:
+        component_record = descriptor["components"][component_name]
+    except KeyError:
+        # No components.
+        component_record = {}
+
+    all_basedir_relpaths = []
+    for basedir_relpath, basedir_record in component_record.items():
+        basedir = args.root_dir / Path(basedir_relpath)
+        optional = basedir_record.get("optional")
+        if optional and not basedir.exists():
+            continue
+        all_basedir_relpaths.append(basedir_relpath)
+
+        # Includes.
+        includes = _dup_list_or_str(basedir_record.get("include"))
+        includes.extend(
+            COMPONENT_DEFAULTS.get(component_name, ComponentDefaults()).includes
+        )
+
+        # Excludes.
+        excludes = _dup_list_or_str(basedir_record.get("exclude"))
+        excludes.extend(
+            COMPONENT_DEFAULTS.get(component_name, ComponentDefaults()).excludes
+        )
+
+        pm = PatternMatcher(
+            includes=includes,
+            excludes=excludes,
+        )
+        pm.add_basedir(basedir)
+        pm.copy_to(
+            destdir=output_dir,
+            destprefix=basedir_relpath + "/",
+            remove_dest=False,
+        )
+
+    # Write a manifest containing relative paths of all base directories.
+    manifest_path = args.manifest
+    if manifest_path is None:
+        manifest_path = output_dir / "artifact_manifest.txt"
+    if manifest_path:
+        manifest_path.write_text("\n".join(all_basedir_relpaths) + "\n")
+
+
+def _dup_list_or_str(v: list[str] | str) -> list[str]:
+    if not v:
+        return []
+    if isinstance(v, str):
+        return [v]
+    return list(v)
+
+
+def load_toml_file(p: Path):
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        # Python <= 3.10 compatibility (requires install of 'toml' package)
+        import toml as tomllib
+    with open(p, "rb") as f:
+        return tomllib.load(f)
 
 
 def main(cl_args: list[str]):
@@ -201,6 +382,35 @@ def main(cl_args: list[str]):
     list_p = sub_p.add_parser("list", help="List matching files to stdout")
     add_pattern_matcher_args(list_p)
     list_p.set_defaults(func=pattern_matcher_action(do_list))
+
+    # 'artifact' command
+    artifact_p = sub_p.add_parser(
+        "artifact", help="Merge artifacts based on a descriptor"
+    )
+    artifact_p.add_argument(
+        "--output-dir", type=Path, required=True, help="Artifact output directory"
+    )
+    artifact_p.add_argument(
+        "--root-dir",
+        type=Path,
+        required=True,
+        help="Source directory to which all descriptor directories are relative",
+    )
+    artifact_p.add_argument(
+        "--descriptor",
+        type=Path,
+        required=True,
+        help="TOML file describing the artifact",
+    )
+    artifact_p.add_argument(
+        "--component", required=True, help="Component within the descriptor to merge"
+    )
+    artifact_p.add_argument(
+        "--manifest",
+        type=Path,
+        help="Manifest text file to write (contains base paths)",
+    )
+    artifact_p.set_defaults(func=do_artifact)
 
     args = p.parse_args(cl_args)
     args.func(args)

--- a/cmake/therock_artifacts.cmake
+++ b/cmake/therock_artifacts.cmake
@@ -1,0 +1,73 @@
+# therock_artifacts.cmake
+# Facilities for bundling artifacts for bootstrapping and subsequent CI/CD
+# phases.
+
+function(therock_provide_artifact slice_name)
+  cmake_parse_arguments(PARSE_ARGV 1 ARG
+    "TARGET_NEUTRAL"
+    "DESCRIPTOR"
+    "COMPONENTS;SUBPROJECT_DEPS"
+  )
+
+  # Normalize arguments.
+  set(_target_name "therock-artifact-${slice_name}")
+  if(TARGET "${_target_name}")
+    message(FATAL_ERROR "Artifact slice '${slice_name}' provided more than once")
+  endif()
+
+  if(NOT ARG_DESCRIPTOR)
+    set(ARG_DESCRIPTOR "artifact.toml")
+  endif()
+  cmake_path(ABSOLUTE_PATH ARG_DESCRIPTOR BASE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  # We make all artifact slices available as therock-artifacts top-level target.
+  if(NOT TARGET therock-artifacts)
+    add_custom_target(therock-artifacts)
+  endif()
+
+  # Determine top-level name.
+  if(ARG_TARGET_NEUTRAL)
+    set(_bundle_name "any")
+  else()
+    set(_bundle_name "${THEROCK_AMDGPU_DIST_BUNDLE_NAME}")
+  endif()
+  set(_artifact_base_name "${slice_name}_${_bundle_name}")
+
+  # Determine dependencies.
+  set(_stamp_file_deps)
+  _therock_cmake_subproject_deps_to_stamp(_stamp_file_deps "stage.stamp" ${ARG_SUBPROJECT_DEPS})
+
+  # Assemble commands.
+  set(_fileset_tool "${THEROCK_SOURCE_DIR}/build_tools/fileset_tool.py")
+  set(_command_list)
+  set(_manifest_files)
+  foreach(_component ${ARG_COMPONENTS})
+    set(_component_dir "${THEROCK_BINARY_DIR}/artifacts/${_artifact_base_name}_${_component}")
+    set(_manifest_file "${_component_dir}/artifact_manifest.txt")
+    list(APPEND _manifest_files "${_manifest_file}")
+    list(APPEND _command_list
+      COMMAND "${Python3_EXECUTABLE}" "${_fileset_tool}" artifact
+        --output-dir "${_component_dir}"
+        --root-dir "${THEROCK_BINARY_DIR}" --descriptor "${ARG_DESCRIPTOR}"
+        --component "${_component}"
+        --manifest "${_manifest_file}"
+    )
+  endforeach()
+
+  # Set up command.
+  message(STATUS "FOOMANIFEST: ${_manifest_files}")
+  add_custom_command(
+    OUTPUT ${_manifest_files}
+    COMMENT "Merging artifact ${slice_name}"
+    ${_command_list}
+    DEPENDS
+      ${_stamp_file_deps}
+      "${ARG_DESCRIPTOR}"
+      "${_fileset_tool}"
+  )
+  add_custom_target(
+    "${_target_name}"
+    DEPENDS ${_manifest_files}
+  )
+  add_dependencies(therock-artifacts "${_target_name}")
+endfunction()

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -7,6 +7,8 @@ therock_cmake_subproject_declare(amd-llvm
   # Note that LLVM top level CMakeLists.txt is in the llvm subdir of the
   # monorepo.
   CMAKE_LISTS_RELPATH "llvm"
+  CMAKE_ARGS
+    -DLLVM_INCLUDE_TESTS=OFF
   INTERFACE_PROGRAM_DIRS
     lib/llvm/bin
   BUILD_DEPS
@@ -48,3 +50,30 @@ therock_cmake_subproject_glob_c_sources(hipify
     src
 )
 therock_cmake_subproject_activate(hipify)
+
+
+################################################################################
+# Artifacts
+################################################################################
+
+therock_provide_artifact(amd-llvm
+  TARGET_NEUTRAL
+  DESCRIPTOR artifact-amd-llvm.toml
+  COMPONENTS
+    run
+    dev
+    dbg
+    doc
+  SUBPROJECT_DEPS
+    amd-llvm
+)
+
+therock_provide_artifact(hipify
+  TARGET_NEUTRAL
+  DESCRIPTOR artifact-hipify.toml
+  COMPONENTS
+    run
+    dbg
+  SUBPROJECT_DEPS
+    hipify
+)

--- a/compiler/artifact-amd-llvm.toml
+++ b/compiler/artifact-amd-llvm.toml
@@ -1,0 +1,13 @@
+[components.dev."compiler/amd-llvm/stage"]
+exclude = [
+  "lib/llvm/lib/clang/**",
+]
+[components.doc."compiler/amd-llvm/stage"]
+[components.run."compiler/amd-llvm/stage"]
+include = [
+  "lib/llvm/bin/**",
+  "lib/llvm/amdgcn/**",
+  "lib/llvm/libexec/**",
+  "lib/llvm/hip/**",
+  "lib/llvm/lib/clang/**",
+]

--- a/compiler/artifact-hipify.toml
+++ b/compiler/artifact-hipify.toml
@@ -1,0 +1,5 @@
+[components.run."compiler/hipify/stage"]
+include = [
+  "bin/**",
+  "libexec/**",
+]


### PR DESCRIPTION
* Ship-ready artifact trees are output to `artifacts/` using a common naming heuristic.
* These are generic artifact slices which split project groups into run/dev/dbg/doc subsets based on slice specific patterns.
* Artifacts can either be target neutral or target-locked, and this is represented in the name.
* The build system produces exploded artifact directories ready for upload/streaming via things like GH action artifacts or direct use in downstream processing.
* Like with systems such as Bazel, much care was taken on preserving convention and directory layout so that the pieces can all fit together systematically.

This is a first step that just produces artifact slices for `base/` and `compiler/`. Still a number of things todo:

* A future step will also produce archive files from these for direct installation.
* I want to add a diagnostic script which reports any duplication/ommissions so that patterns can be easily maintained.
* The build system will have a mode where it can initialize its build tree from an arbitrary set of artifacts from a prior build. This will disable configure/build steps for these pre-built parts and hardwire them to always uptodate.
* Populate the remaining directories (core, math-libs, ml-frameworks).
* Further tune LLVM's build/install configuration to reduce over-built assets at the source.
* Add global build system hooks so that debug symbol separation is done at build time (right now, all of the dbg slices are empty because the build system is either stripping or bundling debug info).
* Probably some additional tweaks needed for Windows specific patterns.