### PR TITLE
Change cmake min version to 3.25.

### DIFF
--- a/.github/workflows/publish_build_manylinux_x86_64.yml
+++ b/.github/workflows/publish_build_manylinux_x86_64.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['main', 'docker*']
     paths:
-    - dockerfiles/**
+    - "dockerfiles/**"
     - .github/workflows/publish_build_manylinux_x86_64.yml
 
 env:

--- a/.github/workflows/publish_build_manylinux_x86_64.yml
+++ b/.github/workflows/publish_build_manylinux_x86_64.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['main', 'docker*']
     paths:
-    - dockerfiles/build_manylinux_x86_64.Dockerfile
+    - dockerfiles/**
     - .github/workflows/publish_build_manylinux_x86_64.yml
 
 env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(FATAL_ERROR "In-source builds are not allowed. Please create a separate build directory.")
 endif()
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.25)
 
 # Set the default build type to Release if not specified
 if(NOT CMAKE_BUILD_TYPE)

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -66,11 +66,11 @@ function(therock_subproject_fetch target_name)
   endif()
   if(ARG_TOUCH)
     list(APPEND _extra
-      INSTALL_COMMAND "${CMAKE_COMMAND}" -E touch ${ARG_TOUCH}
-      INSTALL_BYPRODUCTS ${ARG_TOUCH}
+      BUILD_COMMAND "${CMAKE_COMMAND}" -E touch ${ARG_TOUCH}
+      BUILD_BYPRODUCTS ${ARG_TOUCH}
     )
   else()
-    list(APPEND _extra "INSTALL_COMMAND" "")
+    list(APPEND _extra "BUILD_COMMAND" "")
   endif()
 
   ExternalProject_Add(
@@ -79,7 +79,7 @@ function(therock_subproject_fetch target_name)
     PREFIX "${ARG_PREFIX}"
     SOURCE_DIR "${ARG_SOURCE_DIR}"
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
     TEST_COMMAND ""
     ${_extra}
     ${ARG_UNPARSED_ARGUMENTS}

--- a/dockerfiles/build_manylinux_x86_64.Dockerfile
+++ b/dockerfiles/build_manylinux_x86_64.Dockerfile
@@ -29,7 +29,7 @@ RUN ./install_ccache.sh "4.9" && rm -rf /install-ccache
 
 ######## CMake ########
 WORKDIR /install-cmake
-ENV CMAKE_VERSION="3.30.3"
+ENV CMAKE_VERSION="3.25.2"
 COPY install_cmake.sh ./
 RUN ./install_cmake.sh "${CMAKE_VERSION}" && rm -rf /install-cmake
 


### PR DESCRIPTION
* Uses an older form for one feature that was introduced in 3.26.
* Updates the docker image to install 3.25.2.

Fixes #41.