### PR TITLE
Patch rocm-core to be more compatible with Windows/MSVC.

### DIFF
--- a/patches/amd-mainline/rocm-core/0001-Patch-version-and-getpath-files-for-Windows.patch
+++ b/patches/amd-mainline/rocm-core/0001-Patch-version-and-getpath-files-for-Windows.patch
@@ -1,0 +1,121 @@
+From 0dd798f4768ecc971887fc53bb7c3e70a7f61d43 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Fri, 31 Jan 2025 12:42:08 -0800
+Subject: [PATCH] Patch version and getpath files for Windows.
+
+---
+ rocm_getpath.cpp  | 12 +++++++-----
+ rocm_getpath.h.in | 10 ++++++++--
+ rocm_version.h.in | 10 ++++++++--
+ 3 files changed, 23 insertions(+), 9 deletions(-)
+
+diff --git a/rocm_getpath.cpp b/rocm_getpath.cpp
+index 182b0ba..d02b3b5 100644
+--- a/rocm_getpath.cpp
++++ b/rocm_getpath.cpp
+@@ -25,10 +25,13 @@
+ 
+ #include <string.h>
+ #include <stdlib.h>
+-#include <limits.h> /* PATH_MAX */
+ #include <stdio.h>
++#if defined(_WIN32) || defined(__CYGWIN__)
++// No Windows-specific includes.
++#else
+ #include <link.h>
+ #include <dlfcn.h>
++#endif
+ #include "rocm_getpath.h"
+ 
+ /* Macro for NULL CHECK */
+@@ -39,7 +42,7 @@
+ #define TARGET_LIB_INSTALL_DIR TARGET_LIBRARY_INSTALL_DIR
+ 
+ /* Target Library Name Buf Size */
+-#define LIBRARY_FILENAME_BUFSZ (PATH_MAX+1)
++#define LIBRARY_FILENAME_BUFSZ 4096
+ 
+ /* Internal Function to get Base Path - Ref from Icarus Logic*/
+ static int getROCmBase(char *buf);
+@@ -91,7 +94,7 @@ PathErrors_t getROCmInstallPath( char** InstallPath, unsigned int *InstallPathLe
+ 
+ /* General purpose function that fills the directory to find rocm related stuff */
+ /* returns the offset into the buffer for the terminating NUL or -1 for error */
+-/* The buffer should be at least PATH_MAX */
++/* The buffer should be at least LIBRARY_FILENAME_BUFSZ */
+ static int getROCmBase(char *buf)
+ {
+   int len=0;
+@@ -109,7 +112,7 @@ static int getROCmBase(char *buf)
+          /* Already has at least one terminating */
+          len--;
+       }
+-      if (len > PATH_MAX-1 ) {
++      if (len > LIBRARY_FILENAME_BUFSZ - 1) {
+          return PathValuesTooLong;
+       }
+       strncpy(buf, envStr, len);
+@@ -165,4 +168,3 @@ static int getROCmBase(char *buf)
+   len = strlen(buf);
+   return len;
+ }
+-
+diff --git a/rocm_getpath.h.in b/rocm_getpath.h.in
+index c0eb448..7cf385d 100644
+--- a/rocm_getpath.h.in
++++ b/rocm_getpath.h.in
+@@ -32,7 +32,13 @@
+ extern "C" {
+ #endif  /* __cplusplus */
+ 
+-#define LIB_API_PUBLIC __attribute__ ((visibility ("default")))
++#if defined(_WIN32) || defined(__CYGWIN__)
++#define LIB_API_PUBLIC __declspec(dllexport)
++#define ATTRIBUTE_NON_NULL
++#else
++#define LIB_API_PUBLIC __attribute__((visibility("default")))
++#define ATTRIBUTE_NON_NULL __attribute__((nonnull))
++#endif
+ 
+ /* Get Library Target Build Type */
+ #cmakedefine01 BUILD_SHARED_LIBS
+@@ -62,7 +68,7 @@ typedef enum {
+ //      free(installPath); //caller must free allocated memory after usage.
+ //    ...
+ //  }
+-LIB_API_PUBLIC PathErrors_t getROCmInstallPath(char **InstallPath, unsigned int *InstallPathLen) __attribute__((nonnull)) ;
++LIB_API_PUBLIC PathErrors_t getROCmInstallPath(char **InstallPath, unsigned int *InstallPathLen) ATTRIBUTE_NON_NULL ;
+ 
+ #ifdef __cplusplus
+ }  // end extern "C" block
+diff --git a/rocm_version.h.in b/rocm_version.h.in
+index f9c11a9..6c239da 100644
+--- a/rocm_version.h.in
++++ b/rocm_version.h.in
+@@ -33,7 +33,13 @@ extern "C" {
+ #endif  /* __cplusplus */
+ 
+ 
+-#define LIB_API_PUBLIC __attribute__ ((visibility ("default")))
++#if defined(_WIN32) || defined(__CYGWIN__)
++#define LIB_API_PUBLIC __declspec(dllexport)
++#define ATTRIBUTE_NON_NULL
++#else
++#define LIB_API_PUBLIC __attribute__((visibility("default")))
++#define ATTRIBUTE_NON_NULL __attribute__((nonnull))
++#endif
+ 
+ 
+ #define ROCM_VERSION_MAJOR   @VERSION_MAJOR@
+@@ -52,7 +58,7 @@ typedef enum {
+ 
+ //  API for getting the verion
+ //  Return val :  VerErros : API execution status.  The parameters are valid only when the exetution status is SUCCESS==0
+-LIB_API_PUBLIC VerErrors getROCmVersion(unsigned int* Major, unsigned int* Minor, unsigned int* Patch) __attribute__((nonnull)) ;
++LIB_API_PUBLIC VerErrors getROCmVersion(unsigned int* Major, unsigned int* Minor, unsigned int* Patch) ATTRIBUTE_NON_NULL ;
+ //  Usage :
+ //  int mj=0,mn=0,p=0,ret=0;
+ //  ret=getROCMVersion(&mj,&mn,&p);
+-- 
+2.34.1
+


### PR DESCRIPTION
Progress on https://github.com/nod-ai/TheRock/issues/36, making a larger portion of https://github.com/ROCm/rocm-core/ compile on Windows.

## About the changes

* The `link.h` and `dlfcn.h` headers do not exist on Windows and are only used when `BUILD_SHARED_LIBS` is set.
* The `PATH_MAX` value, defined in `limits.h`, does not exist on Windows. I opted to use a fixed constant value of `4096`, but `FILENAME_MAX` is also an option (see https://stackoverflow.com/a/65174437).
* Attributes like `__attribute__((visibility("default")))` do not exist on all compilers. Added some boilerplate cross platform versions (different approaches are possible too, this is just what I use on other projects).

## How I generated the patch

1. Made changes in the source folder
2. Committed to a branch (https://github.com/ScottTodd/rocm-core/commit/0dd798f4768ecc971887fc53bb7c3e70a7f61d43)
3. Ran
    
    ```
    bash .\build_tools\save_patches.sh rocm-6.3.1 rocm-core
    ```