### PR TITLE
Squelches unhelpful console spam.

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -2,6 +2,11 @@
 # amd-llvm
 ################################################################################
 
+set(_extra_llvm_cmake_args)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  list(APPEND _extra_llvm_cmake_args "-DLLVM_ENABLE_PEDANTIC=OFF")
+endif()
+
 therock_cmake_subproject_declare(amd-llvm
   EXTERNAL_SOURCE_DIR "amd-llvm"
   # Note that LLVM top level CMakeLists.txt is in the llvm subdir of the
@@ -9,6 +14,7 @@ therock_cmake_subproject_declare(amd-llvm
   CMAKE_LISTS_RELPATH "llvm"
   CMAKE_ARGS
     -DLLVM_INCLUDE_TESTS=OFF
+    ${_extra_llvm_cmake_args}
   INTERFACE_PROGRAM_DIRS
     lib/llvm/bin
   BUILD_DEPS


### PR DESCRIPTION
* Adds amd-llvm specific warning flags for sub-projects, disabling some very chatty low signal warnings (`-Wno-documentation-unknown-command -Wno-documentation-pedantic -Wno-unused-command-line-argument`).
* Sets `-DLLVM_ENABLE_PEDANTIC=OFF` for LLVM if building on GCC since it seems that the project doesn't audit this carefully and is full of spam.
* Disables verbose logs of sub-project installation sequences.

Updates #47.