### PR TITLE
Change MsgPack dep to be public on TensileHost.

### DIFF
--- a/patches/amd-mainline/hipBLASLt/0001-Add-explicit-CMake-flags-for-specifying-Tensile-tool.patch
+++ b/patches/amd-mainline/hipBLASLt/0001-Add-explicit-CMake-flags-for-specifying-Tensile-tool.patch
@@ -1,4 +1,4 @@
-From acf6789a60150ad51f5a6a097fdc0929085b420a Mon Sep 17 00:00:00 2001
+From dd6e1f8ca1355df2af969d9e353d65be1a115eec Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 3 Feb 2025 18:04:51 -0800
 Subject: [PATCH 1/2] Add explicit CMake flags for specifying Tensile toolchain

--- a/patches/amd-mainline/hipBLASLt/0002-Update-find_package-for-msgpack-to-work-with-5.x-and.patch
+++ b/patches/amd-mainline/hipBLASLt/0002-Update-find_package-for-msgpack-to-work-with-5.x-and.patch
@@ -1,4 +1,4 @@
-From 057418ce17c80111a8a10d341da7a255c69124a6 Mon Sep 17 00:00:00 2001
+From 8fa1de3ba5d1195d2351bb3b1360bbd41d39a6e7 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 3 Feb 2025 20:28:58 -0800
 Subject: [PATCH 2/2] Update find_package for msgpack to work with 5.x and 6.x.
@@ -7,14 +7,14 @@ Adapted from: https://github.com/msgpack/msgpack-c/wiki/Q%26A#how-to-support-bot
 
 Note that 6.x also defines compile definitions that must be respected.
 ---
- tensilelite/Tensile/Source/lib/CMakeLists.txt | 33 ++++++++++++-------
- 1 file changed, 21 insertions(+), 12 deletions(-)
+ tensilelite/Tensile/Source/lib/CMakeLists.txt | 31 +++++++++++--------
+ 1 file changed, 18 insertions(+), 13 deletions(-)
 
 diff --git a/tensilelite/Tensile/Source/lib/CMakeLists.txt b/tensilelite/Tensile/Source/lib/CMakeLists.txt
-index d055b635..b01ee377 100644
+index d055b635..2b6fc46d 100644
 --- a/tensilelite/Tensile/Source/lib/CMakeLists.txt
 +++ b/tensilelite/Tensile/Source/lib/CMakeLists.txt
-@@ -96,22 +96,31 @@ if(TENSILE_USE_LLVM OR TENSILE_USE_MSGPACK)
+@@ -96,22 +96,27 @@ if(TENSILE_USE_LLVM OR TENSILE_USE_MSGPACK)
  endif()
  
  if(TENSILE_USE_MSGPACK)
@@ -24,12 +24,6 @@ index d055b635..b01ee377 100644
 -    if(TARGET msgpackc-cxx)
 -        get_target_property(msgpack_inc msgpackc-cxx INTERFACE_INCLUDE_DIRECTORIES)
 -    elseif(TARGET msgpackc)
--        get_target_property(msgpack_inc msgpackc INTERFACE_INCLUDE_DIRECTORIES)
--    endif()
--
--    if(DEFINED msgpack_inc)
--        # include C++ headers manually
--        # External header includes included as system files
 +    # See: https://github.com/msgpack/msgpack-c/wiki/Q%26A#how-to-support-both-msgpack-c-c-version-5x-and-6x-
 +    # Prefer 6.x (msgpack-cxx) as that is what we bundle in the build.
 +    find_package(msgpack-cxx CONFIG)
@@ -37,15 +31,11 @@ index d055b635..b01ee377 100644
 +        # Version 6.x
 +        get_target_property(msgpack_inc msgpack-cxx INTERFACE_INCLUDE_DIRECTORIES)
 +        get_target_property(msgpack_defs msgpack-cxx INTERFACE_COMPILE_DEFINITIONS)
-         target_include_directories(TensileHost
-             SYSTEM PRIVATE $<BUILD_INTERFACE:${msgpack_inc}>
-         )
-+        target_compile_definitions(TensileHost PRIVATE $<BUILD_INTERFACE:${msgpack_defs}>)
 +        message(STATUS "Found msgpack-cxx (>=6.x): ${msgpack_inc} ${msgpack_defs}")
 +    else()
 +        # Fallback to <= 5.x
 +        find_package(msgpackc-cxx CONFIG REQUIRED NAMES msgpackc-cxx msgpack)
-+        get_target_property(msgpack_inc msgpackc INTERFACE_INCLUDE_DIRECTORIES)
+         get_target_property(msgpack_inc msgpackc INTERFACE_INCLUDE_DIRECTORIES)
 +        get_target_property(msgpack_defs msgpackc INTERFACE_COMPILE_DEFINITIONS)
 +        message(STATUS "Found msgpack (<=5.x): ${msgpack_inc} ${msgpack_defs}")
      endif()
@@ -53,7 +43,14 @@ index d055b635..b01ee377 100644
 +        SYSTEM PRIVATE $<BUILD_INTERFACE:${msgpack_inc}>
 +    )
 +    target_compile_definitions(TensileHost PRIVATE $<BUILD_INTERFACE:${msgpack_defs}>)
-+
+ 
+-    if(DEFINED msgpack_inc)
+-        # include C++ headers manually
+-        # External header includes included as system files
+-        target_include_directories(TensileHost
+-            SYSTEM PRIVATE $<BUILD_INTERFACE:${msgpack_inc}>
+-        )
+-    endif()
 +    target_compile_definitions(TensileHost PUBLIC -DTENSILE_MSGPACK=1)
  endif()
  

--- a/patches/amd-mainline/hipBLASLt/0002-Update-find_package-for-msgpack-to-work-with-5.x-and.patch
+++ b/patches/amd-mainline/hipBLASLt/0002-Update-find_package-for-msgpack-to-work-with-5.x-and.patch
@@ -1,4 +1,4 @@
-From 8fa1de3ba5d1195d2351bb3b1360bbd41d39a6e7 Mon Sep 17 00:00:00 2001
+From bf134da273be7d9583c0e5b9ef7b08a48b1fa1c6 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 3 Feb 2025 20:28:58 -0800
 Subject: [PATCH 2/2] Update find_package for msgpack to work with 5.x and 6.x.
@@ -7,14 +7,14 @@ Adapted from: https://github.com/msgpack/msgpack-c/wiki/Q%26A#how-to-support-bot
 
 Note that 6.x also defines compile definitions that must be respected.
 ---
- tensilelite/Tensile/Source/lib/CMakeLists.txt | 31 +++++++++++--------
- 1 file changed, 18 insertions(+), 13 deletions(-)
+ tensilelite/Tensile/Source/lib/CMakeLists.txt | 28 +++++++++----------
+ 1 file changed, 13 insertions(+), 15 deletions(-)
 
 diff --git a/tensilelite/Tensile/Source/lib/CMakeLists.txt b/tensilelite/Tensile/Source/lib/CMakeLists.txt
-index d055b635..2b6fc46d 100644
+index d055b635..a8a98690 100644
 --- a/tensilelite/Tensile/Source/lib/CMakeLists.txt
 +++ b/tensilelite/Tensile/Source/lib/CMakeLists.txt
-@@ -96,22 +96,27 @@ if(TENSILE_USE_LLVM OR TENSILE_USE_MSGPACK)
+@@ -96,22 +96,20 @@ if(TENSILE_USE_LLVM OR TENSILE_USE_MSGPACK)
  endif()
  
  if(TENSILE_USE_MSGPACK)
@@ -24,33 +24,28 @@ index d055b635..2b6fc46d 100644
 -    if(TARGET msgpackc-cxx)
 -        get_target_property(msgpack_inc msgpackc-cxx INTERFACE_INCLUDE_DIRECTORIES)
 -    elseif(TARGET msgpackc)
-+    # See: https://github.com/msgpack/msgpack-c/wiki/Q%26A#how-to-support-both-msgpack-c-c-version-5x-and-6x-
-+    # Prefer 6.x (msgpack-cxx) as that is what we bundle in the build.
-+    find_package(msgpack-cxx CONFIG)
-+    if(msgpack-cxx_FOUND)
-+        # Version 6.x
-+        get_target_property(msgpack_inc msgpack-cxx INTERFACE_INCLUDE_DIRECTORIES)
-+        get_target_property(msgpack_defs msgpack-cxx INTERFACE_COMPILE_DEFINITIONS)
-+        message(STATUS "Found msgpack-cxx (>=6.x): ${msgpack_inc} ${msgpack_defs}")
-+    else()
-+        # Fallback to <= 5.x
-+        find_package(msgpackc-cxx CONFIG REQUIRED NAMES msgpackc-cxx msgpack)
-         get_target_property(msgpack_inc msgpackc INTERFACE_INCLUDE_DIRECTORIES)
-+        get_target_property(msgpack_defs msgpackc INTERFACE_COMPILE_DEFINITIONS)
-+        message(STATUS "Found msgpack (<=5.x): ${msgpack_inc} ${msgpack_defs}")
-     endif()
-+    target_include_directories(TensileHost
-+        SYSTEM PRIVATE $<BUILD_INTERFACE:${msgpack_inc}>
-+    )
-+    target_compile_definitions(TensileHost PRIVATE $<BUILD_INTERFACE:${msgpack_defs}>)
- 
+-        get_target_property(msgpack_inc msgpackc INTERFACE_INCLUDE_DIRECTORIES)
+-    endif()
+-
 -    if(DEFINED msgpack_inc)
 -        # include C++ headers manually
 -        # External header includes included as system files
 -        target_include_directories(TensileHost
 -            SYSTEM PRIVATE $<BUILD_INTERFACE:${msgpack_inc}>
 -        )
--    endif()
++    # See: https://github.com/msgpack/msgpack-c/wiki/Q%26A#how-to-support-both-msgpack-c-c-version-5x-and-6x-
++    # Prefer 6.x (msgpack-cxx) as that is what we bundle in the build.
++    find_package(msgpack-cxx CONFIG)
++    if(msgpack-cxx_FOUND)
++        # Version 6.x
++        message(STATUS "Found msgpack-cxx (>=6.x)")
++        target_link_libraries(TensileHost PUBLIC msgpack-cxx)
++    else()
++        # Fallback to <= 5.x
++        find_package(msgpackc-cxx CONFIG REQUIRED NAMES msgpackc-cxx msgpack)
++        message(STATUS "Found msgpack (<=5.x)")
++        target_link_libraries(TensileHost PUBLIC msgpackc)
+     endif()
 +    target_compile_definitions(TensileHost PUBLIC -DTENSILE_MSGPACK=1)
  endif()
  


### PR DESCRIPTION
TensileHost seems to export the ability to include msgpack.hpp to its users and one of them tries to pull it in. This really needs to be a public dep, so I removed the system header surgery and just did it the CMake recommended way. The cost of getting it wrong is catastrophic because you get a sheared dep within the same library across any system installed msgpack and one built private to the project (since the system dep just pollutes /usr/include and will be found regardless if installed).
