### PR TITLE
Add hipSOLVER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,15 +115,15 @@ therock_add_feature(FFT
   DESCRIPTION "Enables fft libraries"
   REQUIRES COMPILER HIP_RUNTIME RAND
 )
-therock_add_feature(SOLVER
-  GROUP MATH_LIBS
-  DESCRIPTION "Enables solver libraries (hipsolver, rocsolver)"
-  REQUIRES COMPILER HIP_RUNTIME BLAS PRIM
-)
 therock_add_feature(SPARSE
   GROUP MATH_LIBS
   DESCRIPTION "Enables sparse libraries (hipsparse, rocsparse)"
   REQUIRES COMPILER HIP_RUNTIME BLAS PRIM
+)
+therock_add_feature(SOLVER
+  GROUP MATH_LIBS
+  DESCRIPTION "Enables solver libraries (hipsolver, rocsolver)"
+  REQUIRES COMPILER HIP_RUNTIME BLAS PRIM SPARSE
 )
 
 # ML-Libs Features.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,19 @@ cmake_dependent_option(THEROCK_ENABLE_CORE "Enable building of core libraries" O
 cmake_dependent_option(THEROCK_ENABLE_COMM_LIBS "Enable building of comm libraries" ON "THEROCK_ENABLE_ALL" OFF)
 cmake_dependent_option(THEROCK_ENABLE_MATH_LIBS "Enable building of math libraries" ON "THEROCK_ENABLE_ALL" OFF)
 cmake_dependent_option(THEROCK_ENABLE_ML_LIBS "Enable building of ML libraries" ON "THEROCK_ENABLE_ALL" OFF)
+option(THEROCK_ENABLE_HOST_MATH "Build all bundled host math libraries by default" OFF)
 option(THEROCK_RESET_FEATURES "One-shot flag which forces all feature flags to their default state for this configuration run" OFF)
+
+# Host Math Features.
+therock_add_feature(HOST_BLAS
+  GROUP HOST_MATH
+  DESCRIPTION "Bundled host BLAS library"
+)
+therock_add_feature(HOST_SUITE_SPARSE
+  GROUP HOST_MATH
+  DESCRIPTION "Bundled SuiteSparse library"
+  REQUIRES HOST_BLAS
+)
 
 # Base Features.
 therock_add_feature(COMPILER
@@ -123,7 +135,7 @@ therock_add_feature(SPARSE
 therock_add_feature(SOLVER
   GROUP MATH_LIBS
   DESCRIPTION "Enables solver libraries (hipsolver, rocsolver)"
-  REQUIRES COMPILER HIP_RUNTIME BLAS PRIM SPARSE
+  REQUIRES COMPILER HIP_RUNTIME BLAS PRIM SPARSE HOST_SUITE_SPARSE
 )
 
 # ML-Libs Features.

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -200,6 +200,7 @@ def main(argv):
             "hipBLASLt",
             "hipFFT",
             "hipRAND",
+            "hipSOLVER",
             "hipSPARSE",
             "rocBLAS",
             "rocFFT",

--- a/cmake/finders/FindBLAS.cmake
+++ b/cmake/finders/FindBLAS.cmake
@@ -1,0 +1,20 @@
+# This finder resolves the virtual BLAS package for sub-projects.
+# It defers to the built host-blas, if available, otherwise, failing.
+cmake_policy(PUSH)
+cmake_policy(SET CMP0057 NEW)
+
+if("OpenBLAS" IN_LIST THEROCK_PROVIDED_PACKAGES)
+  cmake_policy(POP)
+  message(STATUS "Resolving bundled host-blas library from super-project")
+  find_package(OpenBLAS CONFIG REQUIRED)
+  # See: https://cmake.org/cmake/help/latest/module/FindBLAS.html
+  set(BLAS_LINKER_FLAGS)
+  set(BLAS_LIBRARIES OpenBLAS::OpenBLAS)
+  add_library(BLAS::BLAS ALIAS OpenBLAS::OpenBLAS)
+  set(BLAS95_LIBRARIES)
+  set(BLAS95_FOUND FALSE)
+  set(BLAS_FOUND TRUE)
+else()
+  cmake_policy(POP)
+  set(BLAS_FOUND FALSE)
+endif()

--- a/cmake/finders/FindLAPACK.cmake
+++ b/cmake/finders/FindLAPACK.cmake
@@ -1,0 +1,20 @@
+# This finder resolves the virtual BLAS package for sub-projects.
+# It defers to the built host-blas, if available, otherwise, failing.
+cmake_policy(PUSH)
+cmake_policy(SET CMP0057 NEW)
+
+if("OpenBLAS" IN_LIST THEROCK_PROVIDED_PACKAGES)
+  cmake_policy(POP)
+  message(STATUS "Resolving bundled host-blas library from super-project")
+  find_package(OpenBLAS CONFIG REQUIRED)
+  # See: https://cmake.org/cmake/help/latest/module/FindBLAS.html
+  set(LAPACK_LINKER_FLAGS)
+  set(LAPACK_LIBRARIES OpenBLAS::OpenBLAS)
+  add_library(LAPACK::LAPACK ALIAS OpenBLAS::OpenBLAS)
+  set(LAPACK95_LIBRARIES)
+  set(LAPACK95_FOUND FALSE)
+  set(LAPACK_FOUND TRUE)
+else()
+  cmake_policy(POP)
+  set(LAPACK_FOUND FALSE)
+endif()

--- a/cmake/therock_features.cmake
+++ b/cmake/therock_features.cmake
@@ -17,7 +17,7 @@
 function(therock_add_feature feature_name)
   cmake_parse_arguments(PARSE_ARGV 1 ARG
     ""
-    "GROUP;DESCRIPTION"
+    "DEFAULT;GROUP;DESCRIPTION"
     "REQUIRES"
   )
 

--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -369,6 +369,7 @@ function(therock_cmake_subproject_activate target_name)
 
   string(APPEND _init_contents "${_deps_contents}")
   string(APPEND _init_contents "set(THEROCK_IGNORE_PACKAGES \"@_ignore_packages@\")\n")
+  string(APPEND _init_contents "list(PREPEND CMAKE_MODULE_PATH \"${THEROCK_SOURCE_DIR}/cmake/finders\")\n")
   foreach(_private_link_dir ${_private_link_dirs})
     if(THEROCK_VERBOSE)
       message(STATUS "  LINK_DIR: ${_private_link_dir}")

--- a/examples/cpp-sdk-user/CMakeLists.txt
+++ b/examples/cpp-sdk-user/CMakeLists.txt
@@ -57,7 +57,9 @@ if(THEROCK_ENABLE_PRIM)
 endif()
 
 if(THEROCK_ENABLE_SOLVER)
+    find_package(hipsolver CONFIG REQUIRED)
     find_package(rocsolver CONFIG REQUIRED)
+    message(STATUS "hipsolver version: ${hipsolver_VERSION}")
     message(STATUS "rocsolver version: ${rocsolver_VERSION}")
 endif()
 

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -371,6 +371,41 @@ if(THEROCK_ENABLE_SOLVER)
   )
   therock_cmake_subproject_provide_package(rocSOLVER rocsolver lib/cmake/rocsolver)
   therock_cmake_subproject_activate(rocSOLVER)
+  list(APPEND _solver_subproject_names rocSOLVER)
+
+  ##############################################################################
+  # hipSOLVER
+  ##############################################################################
+
+  therock_cmake_subproject_declare(hipSOLVER
+    EXTERNAL_SOURCE_DIR "hipSOLVER"
+    BACKGROUND_BUILD
+    CMAKE_ARGS
+      -DHIP_PLATFORM=amd
+      -DROCM_PATH=
+      -DROCM_DIR=
+      -DBUILD_HIPSPARSE_TESTS=OFF
+      -DBUILD_WITH_SPARSE=ON
+      # Requires LAPACK
+      -DBUILD_CLIENTS_BENCHMARKS=OFF
+      -DBUILD_CLIENTS_TESTS=OFF
+    COMPILER_TOOLCHAIN
+      amd-hip
+    BUILD_DEPS
+      rocBLAS
+      rocSOLVER
+      rocSPARSE
+      therock-SuiteSparse
+    RUNTIME_DEPS
+      hip-clr
+  )
+  therock_cmake_subproject_glob_c_sources(hipSOLVER
+    SUBDIRS
+      .
+  )
+  therock_cmake_subproject_provide_package(hipSOLVER hipsolver lib/cmake/hipsolver)
+  therock_cmake_subproject_activate(hipSOLVER)
+  list(APPEND _solver_subproject_names hipSOLVER)
 
   therock_provide_artifact(solver
     DESCRIPTOR artifact-solver.toml
@@ -380,10 +415,9 @@ if(THEROCK_ENABLE_SOLVER)
       doc
       lib
       run
-    SUBPROJECT_DEPS rocSOLVER
+    SUBPROJECT_DEPS ${_solver_subproject_names}
   )
 endif(THEROCK_ENABLE_SOLVER)
-
 
 if(THEROCK_ENABLE_FFT)
   ##############################################################################

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -406,7 +406,7 @@ if(THEROCK_ENABLE_SOLVER)
   )
   therock_cmake_subproject_provide_package(hipSOLVER hipsolver lib/cmake/hipsolver)
   therock_cmake_subproject_activate(hipSOLVER)
-  list(APPEND _solver_subproject_names hipSOLVER therock-SuiteSparse)
+  list(APPEND _solver_subproject_names hipSOLVER)
 
   therock_provide_artifact(solver
     DESCRIPTOR artifact-solver.toml

--- a/math-libs/CMakeLists.txt
+++ b/math-libs/CMakeLists.txt
@@ -385,19 +385,20 @@ if(THEROCK_ENABLE_SOLVER)
       -DROCM_PATH=
       -DROCM_DIR=
       -DBUILD_HIPSPARSE_TESTS=OFF
+      # BUILD_WITH_SPARSE converts rocsparse and cholmod to build time vs
+      # runtime/dlopen deps.
       -DBUILD_WITH_SPARSE=ON
       # Requires LAPACK
       -DBUILD_CLIENTS_BENCHMARKS=OFF
       -DBUILD_CLIENTS_TESTS=OFF
     COMPILER_TOOLCHAIN
       amd-hip
-    BUILD_DEPS
+    RUNTIME_DEPS
+      hip-clr
       rocBLAS
       rocSOLVER
       rocSPARSE
       therock-SuiteSparse
-    RUNTIME_DEPS
-      hip-clr
   )
   therock_cmake_subproject_glob_c_sources(hipSOLVER
     SUBDIRS
@@ -405,7 +406,7 @@ if(THEROCK_ENABLE_SOLVER)
   )
   therock_cmake_subproject_provide_package(hipSOLVER hipsolver lib/cmake/hipsolver)
   therock_cmake_subproject_activate(hipSOLVER)
-  list(APPEND _solver_subproject_names hipSOLVER)
+  list(APPEND _solver_subproject_names hipSOLVER therock-SuiteSparse)
 
   therock_provide_artifact(solver
     DESCRIPTOR artifact-solver.toml

--- a/math-libs/artifact-solver.toml
+++ b/math-libs/artifact-solver.toml
@@ -9,3 +9,10 @@
 [components.dev."math-libs/hipSOLVER/stage"]
 [components.doc."math-libs/hipSOLVER/stage"]
 [components.lib."math-libs/hipSOLVER/stage"]
+
+# therock-SuiteSparse
+# We only need to distribute the runtime libcholmod dep, and since hipsolver
+# is the only thing that distributes it, we bundle it here. However, in the
+# future, we may need a dedicated trampoline project/artifact if multiple
+# things end up depending on it.
+[components.lib."third-party/SuiteSparse/stage"]

--- a/math-libs/artifact-solver.toml
+++ b/math-libs/artifact-solver.toml
@@ -9,10 +9,3 @@
 [components.dev."math-libs/hipSOLVER/stage"]
 [components.doc."math-libs/hipSOLVER/stage"]
 [components.lib."math-libs/hipSOLVER/stage"]
-
-# therock-SuiteSparse
-# We only need to distribute the runtime libcholmod dep, and since hipsolver
-# is the only thing that distributes it, we bundle it here. However, in the
-# future, we may need a dedicated trampoline project/artifact if multiple
-# things end up depending on it.
-[components.lib."third-party/SuiteSparse/stage"]

--- a/math-libs/artifact-solver.toml
+++ b/math-libs/artifact-solver.toml
@@ -3,3 +3,9 @@
 [components.dev."math-libs/rocSOLVER/stage"]
 [components.doc."math-libs/rocSOLVER/stage"]
 [components.lib."math-libs/rocSOLVER/stage"]
+
+# hipSOLVER
+[components.dbg."math-libs/hipSOLVER/stage"]
+[components.dev."math-libs/hipSOLVER/stage"]
+[components.doc."math-libs/hipSOLVER/stage"]
+[components.lib."math-libs/hipSOLVER/stage"]

--- a/math-libs/hipSOLVER
+++ b/math-libs/hipSOLVER
@@ -1,0 +1,1 @@
+../sources/hipSOLVER

--- a/math-libs/post_hook_hipSOLVER.cmake
+++ b/math-libs/post_hook_hipSOLVER.cmake
@@ -6,4 +6,5 @@ therock_set_install_rpath(
     hipsolver
   PATHS
     .
+    suitesparse/lib
 )

--- a/math-libs/post_hook_hipSOLVER.cmake
+++ b/math-libs/post_hook_hipSOLVER.cmake
@@ -6,5 +6,5 @@ therock_set_install_rpath(
     hipsolver
   PATHS
     .
-    suitesparse/lib
+    host-math/lib
 )

--- a/math-libs/post_hook_hipSOLVER.cmake
+++ b/math-libs/post_hook_hipSOLVER.cmake
@@ -1,0 +1,9 @@
+list(APPEND CMAKE_MODULE_PATH "${THEROCK_SOURCE_DIR}/cmake")
+include(therock_rpath)
+
+therock_set_install_rpath(
+  TARGETS
+    hipsolver
+  PATHS
+    .
+)

--- a/math-libs/pre_hook_hipSOLVER.cmake
+++ b/math-libs/pre_hook_hipSOLVER.cmake
@@ -1,0 +1,3 @@
+# TODO: hipSOLVER includes <suitesparse/cholmod.h> but the include directory
+# specified via `-I` already points to the subdirectory. Needs a fix.
+include_directories("${THEROCK_BINARY_DIR}/third-party/SuiteSparse/stage/include")

--- a/math-libs/pre_hook_hipSOLVER.cmake
+++ b/math-libs/pre_hook_hipSOLVER.cmake
@@ -1,3 +1,0 @@
-# TODO: hipSOLVER includes <suitesparse/cholmod.h> but the include directory
-# specified via `-I` already points to the subdirectory. Needs a fix.
-include_directories("${THEROCK_BINARY_DIR}/third-party/SuiteSparse/stage/include")

--- a/patches/amd-mainline/hipSOLVER/0001-Use-proper-include-path-for-cholmod.h.patch
+++ b/patches/amd-mainline/hipSOLVER/0001-Use-proper-include-path-for-cholmod.h.patch
@@ -1,0 +1,28 @@
+From 36f2942dfd91c72e44aad6b8db6e3d0e1606aaf6 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Tue, 11 Feb 2025 17:43:45 -0800
+Subject: [PATCH] Use proper include path for cholmod.h.
+
+It appears that the `SuiteSparse::CHOLMOD` CMake library advertises its include directory as `$PREFIX/include/suitesparse`, making the proper way to include it `#include <cholmod.h>`. When installed in the system `/usr` prefix, the `suitesparse/cholmod.h` path works by accident. When using a custom built suitesparse at a custom location, this is not so.
+
+I believe that this change is the correct way to do it for all configurations, based on how the SuiteSparse library is set up.
+---
+ library/src/amd_detail/dlopen/cholmod.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/library/src/amd_detail/dlopen/cholmod.hpp b/library/src/amd_detail/dlopen/cholmod.hpp
+index 0864172..342ed4f 100644
+--- a/library/src/amd_detail/dlopen/cholmod.hpp
++++ b/library/src/amd_detail/dlopen/cholmod.hpp
+@@ -24,7 +24,7 @@
+ #include "lib_macros.hpp"
+ 
+ #ifdef HAVE_ROCSPARSE
+-#include <suitesparse/cholmod.h>
++#include <cholmod.h>
+ #else
+ 
+ // constants
+-- 
+2.43.0
+

--- a/patches/amd-mainline/rocminfo/0001-Use-idomatic-approach-to-extending-CMAKE_MODULE_PATH.patch
+++ b/patches/amd-mainline/rocminfo/0001-Use-idomatic-approach-to-extending-CMAKE_MODULE_PATH.patch
@@ -1,0 +1,28 @@
+From 8cb1187a0f684f2031d9cae7996efbb3fc4fa590 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Tue, 11 Feb 2025 22:10:22 -0800
+Subject: [PATCH] Use idomatic approach to extending CMAKE_MODULE_PATH.
+
+There are many reasons why there may already be a CMAKE_MODULE_PATH defined. The idiomatic way to extend it in a project is via `list(APPEND`.
+---
+ CMakeLists.txt | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index df6755a..ecdcf77 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -50,9 +50,7 @@ endif()
+ # Default to ON
+ option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+ ## Set default module path if not already set
+-if(NOT DEFINED CMAKE_MODULE_PATH)
+-    set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+-endif()
++list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+ ## Include common cmake modules
+ include(utils)
+ 
+-- 
+2.43.0
+

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(fmt)
 add_subdirectory(msgpack-cxx)
 add_subdirectory(nlohmann-json)
 add_subdirectory(FunctionalPlus)
+add_subdirectory(SuiteSparse)
 
 # frugally-deep depends on eigen, FunctionalPlus and nlohmann-json
 add_subdirectory(frugally-deep)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -7,7 +7,14 @@ add_subdirectory(fmt)
 add_subdirectory(msgpack-cxx)
 add_subdirectory(nlohmann-json)
 add_subdirectory(FunctionalPlus)
-add_subdirectory(SuiteSparse)
 
 # frugally-deep depends on eigen, FunctionalPlus and nlohmann-json
 add_subdirectory(frugally-deep)
+
+# Host math libraries.
+if(THEROCK_ENABLE_HOST_BLAS)
+  add_subdirectory(host-blas)
+endif()
+if(THEROCK_ENABLE_HOST_SUITE_SPARSE)
+  add_subdirectory(SuiteSparse)
+endif()

--- a/third-party/SuiteSparse/CMakeLists.txt
+++ b/third-party/SuiteSparse/CMakeLists.txt
@@ -8,22 +8,24 @@ therock_cmake_subproject_declare(therock-SuiteSparse
   BACKGROUND_BUILD
   EXCLUDE_FROM_ALL
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
+  INSTALL_DESTINATION "lib/suitesparse"
   CMAKE_ARGS
     "-DSUITESPARSE_ENABLE_PROJECTS=\"suitesparse_config;cholmod\""
     -DCHOLMOD_SUPERNODAL=OFF # requires Cholesky, BLAS, and LAPACK
     -DBUILD_STATIC_LIBS=OFF
     -DSUITESPARSE_USE_CUDA=OFF
+    -DSUITESPARSE_USE_OPENMP=OFF
 )
 therock_cmake_subproject_provide_package(
-  therock-SuiteSparse AMD lib/cmake/AMD)
+  therock-SuiteSparse AMD lib/suitesparse/lib/cmake/AMD)
 therock_cmake_subproject_provide_package(
-  therock-SuiteSparse CAMD lib/cmake/CAMD)
+  therock-SuiteSparse CAMD lib/suitesparse/lib/cmake/CAMD)
 therock_cmake_subproject_provide_package(
-  therock-SuiteSparse CCOLAMD lib/cmake/CCOLAMD)
+  therock-SuiteSparse CCOLAMD lib/suitesparse/lib/cmake/CCOLAMD)
 therock_cmake_subproject_provide_package(
-  therock-SuiteSparse CHOLMOD lib/cmake/CHOLMOD)
+  therock-SuiteSparse CHOLMOD lib/suitesparse/lib/cmake/CHOLMOD)
 therock_cmake_subproject_provide_package(
-  therock-SuiteSparse COLAMD lib/cmake/COLAMD)
+  therock-SuiteSparse COLAMD lib/suitesparse/lib/cmake/COLAMD)
 therock_cmake_subproject_provide_package(
-  therock-SuiteSparse SuiteSparse_config lib/cmake/SuiteSparse_config)
+  therock-SuiteSparse SuiteSparse_config lib/suitesparse/lib/cmake/SuiteSparse_config)
 therock_cmake_subproject_activate(therock-SuiteSparse)

--- a/third-party/SuiteSparse/CMakeLists.txt
+++ b/third-party/SuiteSparse/CMakeLists.txt
@@ -1,0 +1,29 @@
+therock_subproject_fetch(therock-SuiteSparse-sources
+  CMAKE_PROJECT
+  URL https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.8.3.tar.gz
+  URL_HASH SHA256=ce39b28d4038a09c14f21e02c664401be73c0cb96a9198418d6a98a7db73a259
+)
+
+therock_cmake_subproject_declare(therock-SuiteSparse
+  BACKGROUND_BUILD
+  EXCLUDE_FROM_ALL
+  EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
+  CMAKE_ARGS
+    "-DSUITESPARSE_ENABLE_PROJECTS=\"suitesparse_config;cholmod\""
+    -DCHOLMOD_SUPERNODAL=OFF # requires Cholesky, BLAS, and LAPACK
+    -DBUILD_STATIC_LIBS=OFF
+    -DSUITESPARSE_USE_CUDA=OFF
+)
+therock_cmake_subproject_provide_package(
+  therock-SuiteSparse AMD lib/cmake/AMD)
+therock_cmake_subproject_provide_package(
+  therock-SuiteSparse CAMD lib/cmake/CAMD)
+therock_cmake_subproject_provide_package(
+  therock-SuiteSparse CCOLAMD lib/cmake/CCOLAMD)
+therock_cmake_subproject_provide_package(
+  therock-SuiteSparse CHOLMOD lib/cmake/CHOLMOD)
+therock_cmake_subproject_provide_package(
+  therock-SuiteSparse COLAMD lib/cmake/COLAMD)
+therock_cmake_subproject_provide_package(
+  therock-SuiteSparse SuiteSparse_config lib/cmake/SuiteSparse_config)
+therock_cmake_subproject_activate(therock-SuiteSparse)

--- a/third-party/SuiteSparse/CMakeLists.txt
+++ b/third-party/SuiteSparse/CMakeLists.txt
@@ -12,7 +12,6 @@ therock_cmake_subproject_declare(therock-SuiteSparse
   CMAKE_ARGS
     "-DSUITESPARSE_ENABLE_PROJECTS=\"suitesparse_config;cholmod\""
     -DBLA_VENDOR=OpenBLAS
-    -DCHOLMOD_SUPERNODAL=OFF # requires Cholesky, BLAS, and LAPACK
     -DBUILD_STATIC_LIBS=OFF
     -DSUITESPARSE_USE_CUDA=OFF
     -DSUITESPARSE_USE_OPENMP=OFF

--- a/third-party/SuiteSparse/CMakeLists.txt
+++ b/third-party/SuiteSparse/CMakeLists.txt
@@ -16,6 +16,7 @@ therock_cmake_subproject_declare(therock-SuiteSparse
     -DBUILD_STATIC_LIBS=OFF
     -DSUITESPARSE_USE_CUDA=OFF
     -DSUITESPARSE_USE_OPENMP=OFF
+    -DSUITESPARSE_USE_FORTRAN=OFF
   RUNTIME_DEPS
     therock-host-blas
 )

--- a/third-party/SuiteSparse/CMakeLists.txt
+++ b/third-party/SuiteSparse/CMakeLists.txt
@@ -8,24 +8,38 @@ therock_cmake_subproject_declare(therock-SuiteSparse
   BACKGROUND_BUILD
   EXCLUDE_FROM_ALL
   EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
-  INSTALL_DESTINATION "lib/suitesparse"
+  INSTALL_DESTINATION "lib/host-math"
   CMAKE_ARGS
     "-DSUITESPARSE_ENABLE_PROJECTS=\"suitesparse_config;cholmod\""
+    -DBLA_VENDOR=OpenBLAS
     -DCHOLMOD_SUPERNODAL=OFF # requires Cholesky, BLAS, and LAPACK
     -DBUILD_STATIC_LIBS=OFF
     -DSUITESPARSE_USE_CUDA=OFF
     -DSUITESPARSE_USE_OPENMP=OFF
+  RUNTIME_DEPS
+    therock-host-blas
 )
 therock_cmake_subproject_provide_package(
-  therock-SuiteSparse AMD lib/suitesparse/lib/cmake/AMD)
+  therock-SuiteSparse AMD lib/host-math/lib/cmake/AMD)
 therock_cmake_subproject_provide_package(
-  therock-SuiteSparse CAMD lib/suitesparse/lib/cmake/CAMD)
+  therock-SuiteSparse CAMD lib/host-math/lib/cmake/CAMD)
 therock_cmake_subproject_provide_package(
-  therock-SuiteSparse CCOLAMD lib/suitesparse/lib/cmake/CCOLAMD)
+  therock-SuiteSparse CCOLAMD lib/host-math/lib/cmake/CCOLAMD)
 therock_cmake_subproject_provide_package(
-  therock-SuiteSparse CHOLMOD lib/suitesparse/lib/cmake/CHOLMOD)
+  therock-SuiteSparse CHOLMOD lib/host-math/lib/cmake/CHOLMOD)
 therock_cmake_subproject_provide_package(
-  therock-SuiteSparse COLAMD lib/suitesparse/lib/cmake/COLAMD)
+  therock-SuiteSparse COLAMD lib/host-math/lib/cmake/COLAMD)
 therock_cmake_subproject_provide_package(
-  therock-SuiteSparse SuiteSparse_config lib/suitesparse/lib/cmake/SuiteSparse_config)
+  therock-SuiteSparse SuiteSparse_config lib/host-math/lib/cmake/SuiteSparse_config)
 therock_cmake_subproject_activate(therock-SuiteSparse)
+
+therock_provide_artifact(host-suite-sparse
+  DESCRIPTOR artifact-host-suite-sparse.toml
+  COMPONENTS
+    dbg
+    dev
+    doc
+    lib
+    run
+  SUBPROJECT_DEPS therock-SuiteSparse
+)

--- a/third-party/SuiteSparse/artifact-host-suite-sparse.toml
+++ b/third-party/SuiteSparse/artifact-host-suite-sparse.toml
@@ -1,0 +1,5 @@
+# SuiteSparse
+[components.dbg."third-party/SuiteSparse/stage"]
+[components.dev."third-party/SuiteSparse/stage"]
+[components.doc."third-party/SuiteSparse/stage"]
+[components.lib."third-party/SuiteSparse/stage"]

--- a/third-party/host-blas/CMakeLists.txt
+++ b/third-party/host-blas/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Right now we only support OpenBLAS as the host BLAS library.
+# This will be extended later, including allowing to use the system BLAS of
+# your choice.
+
+therock_subproject_fetch(therock-OpenBLAS-sources
+  CMAKE_PROJECT
+  URL https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.29/OpenBLAS-0.3.29.tar.gz
+  URL_HASH SHA256=38240eee1b29e2bde47ebb5d61160207dc68668a54cac62c076bb5032013b1eb
+  # Originally posted MD5 was recomputed as SHA256 manually:
+  # URL_HASH MD5=853a0c5c0747c5943e7ef4bbb793162d
+)
+
+therock_cmake_subproject_declare(therock-host-blas
+  BACKGROUND_BUILD
+  EXCLUDE_FROM_ALL
+  EXTERNAL_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/source"
+  INSTALL_DESTINATION "lib/host-math"
+  INTERFACE_LINK_DIRS "lib/host-math/lib"
+  CMAKE_ARGS
+    -DBUILD_SHARED_LIBS=ON
+    -DDYNAMIC_ARCH=ON
+)
+therock_cmake_subproject_provide_package(therock-host-blas OpenBLAS lib/host-math/lib/cmake/OpenBLAS)
+therock_cmake_subproject_activate(therock-host-blas)
+
+therock_provide_artifact(host-blas
+  DESCRIPTOR artifact-host-OpenBLAS.toml
+  COMPONENTS
+    dbg
+    dev
+    doc
+    lib
+    run
+  SUBPROJECT_DEPS therock-host-blas
+)

--- a/third-party/host-blas/CMakeLists.txt
+++ b/third-party/host-blas/CMakeLists.txt
@@ -18,7 +18,11 @@ therock_cmake_subproject_declare(therock-host-blas
   INTERFACE_LINK_DIRS "lib/host-math/lib"
   CMAKE_ARGS
     -DBUILD_SHARED_LIBS=ON
-    -DDYNAMIC_ARCH=ON
+    # TODO: DYNAMIC_ARCH=ON produces illegal elf files
+    # See: https://github.com/nod-ai/TheRock/issues/83
+    -DDYNAMIC_ARCH=OFF
+    -DC_LAPACK=ON
+    -DBUILD_TESTING=OFF
 )
 therock_cmake_subproject_provide_package(therock-host-blas OpenBLAS lib/host-math/lib/cmake/OpenBLAS)
 therock_cmake_subproject_activate(therock-host-blas)

--- a/third-party/host-blas/artifact-host-OpenBLAS.toml
+++ b/third-party/host-blas/artifact-host-OpenBLAS.toml
@@ -1,0 +1,5 @@
+# SuiteSparse
+[components.dbg."third-party/host-blas/stage"]
+[components.dev."third-party/host-blas/stage"]
+[components.doc."third-party/host-blas/stage"]
+[components.lib."third-party/host-blas/stage"]


### PR DESCRIPTION
* Adds host-math group and includes OpenBLAS and SuiteSparse in it to provide libcholmod (so that we have the option to avoid system deps for these).
* Includes upstream patch https://github.com/ROCm/hipSOLVER/pull/364
* Includes upstream patch https://github.com/ROCm/rocminfo/pull/97

Includes workarounds for #82, #83