### PR TITLE
Setup initial workflow for building on Windows.

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -1,0 +1,77 @@
+name: Build Windows Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_version:
+        type: string
+        default: ADHOCBUILD
+
+  workflow_call:
+    inputs:
+      package_version:
+        type: string
+        default: ADHOCBUILD
+
+jobs:
+  build_windows_packages:
+    name: Build Windows Packages
+    runs-on: windows-2022  # TODO(#36): move to cluster of CPU builders like `azure-windows-scale-nod-ai`
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: true
+    steps:
+      - name: Enabling git symlinks
+        run: git config --global core.symlinks true
+      - name: "Checking out repository"
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.11"
+
+      - name: Install ninja
+        run: choco install ninja --yes
+
+      - name: Fetch sources
+        run: |
+          git config --global user.email "nobody@amd.com"
+          git config --global user.name "Nobody"
+          python ./build_tools/fetch_sources.py --depth 1
+      # TODO(scotttodd): Get symlinks working on CI runners instead of this
+      - name: Replace symlinks with copies
+        run: ./build_tools/patch_symlinks_for_windows_ci.sh
+
+      - name: Configure MSVC
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      # TODO: We shouldn't be using a cache on actual release branches, but it
+      # really helps for iteration time.
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@53911442209d5c18de8a31615e0923161e435875 # v1.2.16
+        with:
+          key: windows-build-packages-v1
+
+      - name: Configure Projects
+        run: |
+          # Generate a new build id.
+          package_version="${{ inputs.package_version }}"
+          echo "Building package ${package_version}"
+
+          # Build.
+          cmake -B build -GNinja . \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu \
+            -DTHEROCK_PACKAGE_VERSION="${package_version}" \
+            -DTHEROCK_ENABLE_RCCL=OFF \
+            -DTHEROCK_ENABLE_MATH_LIBS=OFF \
+            -DTHEROCK_ENABLE_ML_LIBS=OFF
+
+      - name: Build Projects
+        run: cmake --build build
+
+      - name: Report
+        if: ${{ !cancelled() }}
+        run: |
+          ls -lh build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
     name: Build Linux Packages
     uses: ./.github/workflows/build_linux_packages.yml
 
+  build_windows_packages:
+    name: Build Windows Packages
+    uses: ./.github/workflows/build_windows_packages.yml
+
   # build_python_packages:
   #   name: Build Python Packages
   #   uses: ./.github/workflows/build_python_packages.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,14 +109,19 @@ endif()
 # don't be fooled).
 add_subdirectory(third-party)
 add_subdirectory(base)
-add_subdirectory(compiler)
-add_subdirectory(core)
-add_subdirectory(comm-libs)
-if(THEROCK_ENABLE_MATH_LIBS)
-  add_subdirectory(math-libs)
-endif()
-if(THEROCK_ENABLE_ML_LIBS)
-  add_subdirectory(ml-libs)
+
+if(NOT WIN32)
+  add_subdirectory(compiler)
+  add_subdirectory(core)
+  add_subdirectory(comm-libs)
+  if(THEROCK_ENABLE_MATH_LIBS)
+    add_subdirectory(math-libs)
+  endif()
+  if(THEROCK_ENABLE_ML_LIBS)
+    add_subdirectory(ml-libs)
+  endif()
+else()
+  # TODO(#36): Enable more project builds on Windows and/or make the full list configurable.
 endif()
 
 

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -16,10 +16,16 @@ therock_cmake_subproject_activate(rocm-cmake)
 # rocm-core
 ################################################################################
 
+if(WIN32)
+  set(_shared_libs_arg "OFF")
+else()
+  set(_shared_libs_arg "ON")
+endif()
+
 therock_cmake_subproject_declare(rocm-core
   EXTERNAL_SOURCE_DIR "rocm-core"
   CMAKE_ARGS
-    "-DBUILD_SHARED_LIBS=ON"
+    "-DBUILD_SHARED_LIBS=${_shared_libs_arg}"
     "-DROCM_VERSION=${ROCM_MAJOR_VERSION}.${ROCM_MINOR_VERSION}.${ROCM_PATCH_VERSION}"
 )
 therock_cmake_subproject_glob_c_sources(rocm-core
@@ -32,6 +38,8 @@ therock_cmake_subproject_activate(rocm-core)
 ################################################################################
 # rocm_smi_lib
 ################################################################################
+
+if(NOT WIN32)  # TODO(#36): Enable on Windows and/or make subproject inclusion generally optional
 
 therock_cmake_subproject_declare(rocm_smi_lib
   EXTERNAL_SOURCE_DIR "rocm_smi_lib"
@@ -46,11 +54,15 @@ therock_cmake_subproject_glob_c_sources(rocm_smi_lib
 therock_cmake_subproject_provide_package(rocm_smi_lib rocm_smi lib/cmake/rocm_smi)
 therock_cmake_subproject_activate(rocm_smi_lib)
 
+endif()
+
 
 ################################################################################
 # rocprofiler-register
 # This is a stub that helps runtime libraries and profiles rendezvous
 ################################################################################
+
+if(NOT WIN32)  # TODO(#36): Enable on Windows and/or make subproject inclusion generally optional
 
 therock_cmake_subproject_declare(rocprofiler-register
   EXTERNAL_SOURCE_DIR "rocprofiler-register"
@@ -65,6 +77,8 @@ therock_cmake_subproject_glob_c_sources(rocprofiler-register
 therock_cmake_subproject_provide_package(rocprofiler-register
   rocprofiler-register lib/cmake/rocprofiler-register)
 therock_cmake_subproject_activate(rocprofiler-register)
+
+endif()
 
 
 ################################################################################
@@ -87,6 +101,13 @@ therock_cmake_subproject_activate(rocm-half)
 # Artifacts
 ################################################################################
 
+set(_optional_subproject_deps)
+if(NOT WIN32)
+  # TODO(#36): Enable on Windows and/or make subproject inclusion generally optional
+  list(APPEND _optional_subproject_deps rocm_smi_lib)
+  list(APPEND _optional_subproject_deps rocprofiler-register)
+endif()
+
 therock_provide_artifact(base
   TARGET_NEUTRAL
   DESCRIPTOR artifact.toml
@@ -98,9 +119,8 @@ therock_provide_artifact(base
     run
     test
   SUBPROJECT_DEPS
+    ${_optional_subproject_deps}
     rocm-cmake
     rocm-core
-    rocm_smi_lib
-    rocprofiler-register
     rocm-half
 )

--- a/build_tools/patch_symlinks_for_windows_ci.sh
+++ b/build_tools/patch_symlinks_for_windows_ci.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Replaces symlinks for source folders with direct copies of files.
+# This helps set up files for Windows CI runners that do not have symlinks
+# fully configured. This should usually *NOT* be run on development machines
+# since it makes destructive changes.
+
+this_dir="$(cd $(dirname $0) && pwd)"
+root_dir="$(cd $this_dir/.. && pwd)"
+
+cd ${root_dir}
+
+# Remove the original symlinks.
+rm base/half
+rm base/rocm-cmake
+rm base/rocm-core
+
+# Delete .git folders which are symlinks too. CI doesn't need them.
+rm -rf sources/half/.git
+rm -rf sources/rocm-cmake/.git
+rm -rf sources/rocm-core/.git
+
+# Copy from sources/ to where the symlinks were.
+cp -r sources/half base
+cp -r sources/rocm-cmake base
+cp -r sources/rocm-core base

--- a/patches/amd-mainline/rocm-core/0001-Patch-version-and-getpath-files-for-Windows.patch
+++ b/patches/amd-mainline/rocm-core/0001-Patch-version-and-getpath-files-for-Windows.patch
@@ -1,0 +1,121 @@
+From 0dd798f4768ecc971887fc53bb7c3e70a7f61d43 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Fri, 31 Jan 2025 12:42:08 -0800
+Subject: [PATCH] Patch version and getpath files for Windows.
+
+---
+ rocm_getpath.cpp  | 12 +++++++-----
+ rocm_getpath.h.in | 10 ++++++++--
+ rocm_version.h.in | 10 ++++++++--
+ 3 files changed, 23 insertions(+), 9 deletions(-)
+
+diff --git a/rocm_getpath.cpp b/rocm_getpath.cpp
+index 182b0ba..d02b3b5 100644
+--- a/rocm_getpath.cpp
++++ b/rocm_getpath.cpp
+@@ -25,10 +25,13 @@
+ 
+ #include <string.h>
+ #include <stdlib.h>
+-#include <limits.h> /* PATH_MAX */
+ #include <stdio.h>
++#if defined(_WIN32) || defined(__CYGWIN__)
++// No Windows-specific includes.
++#else
+ #include <link.h>
+ #include <dlfcn.h>
++#endif
+ #include "rocm_getpath.h"
+ 
+ /* Macro for NULL CHECK */
+@@ -39,7 +42,7 @@
+ #define TARGET_LIB_INSTALL_DIR TARGET_LIBRARY_INSTALL_DIR
+ 
+ /* Target Library Name Buf Size */
+-#define LIBRARY_FILENAME_BUFSZ (PATH_MAX+1)
++#define LIBRARY_FILENAME_BUFSZ 4096
+ 
+ /* Internal Function to get Base Path - Ref from Icarus Logic*/
+ static int getROCmBase(char *buf);
+@@ -91,7 +94,7 @@ PathErrors_t getROCmInstallPath( char** InstallPath, unsigned int *InstallPathLe
+ 
+ /* General purpose function that fills the directory to find rocm related stuff */
+ /* returns the offset into the buffer for the terminating NUL or -1 for error */
+-/* The buffer should be at least PATH_MAX */
++/* The buffer should be at least LIBRARY_FILENAME_BUFSZ */
+ static int getROCmBase(char *buf)
+ {
+   int len=0;
+@@ -109,7 +112,7 @@ static int getROCmBase(char *buf)
+          /* Already has at least one terminating */
+          len--;
+       }
+-      if (len > PATH_MAX-1 ) {
++      if (len > LIBRARY_FILENAME_BUFSZ - 1) {
+          return PathValuesTooLong;
+       }
+       strncpy(buf, envStr, len);
+@@ -165,4 +168,3 @@ static int getROCmBase(char *buf)
+   len = strlen(buf);
+   return len;
+ }
+-
+diff --git a/rocm_getpath.h.in b/rocm_getpath.h.in
+index c0eb448..7cf385d 100644
+--- a/rocm_getpath.h.in
++++ b/rocm_getpath.h.in
+@@ -32,7 +32,13 @@
+ extern "C" {
+ #endif  /* __cplusplus */
+ 
+-#define LIB_API_PUBLIC __attribute__ ((visibility ("default")))
++#if defined(_WIN32) || defined(__CYGWIN__)
++#define LIB_API_PUBLIC __declspec(dllexport)
++#define ATTRIBUTE_NON_NULL
++#else
++#define LIB_API_PUBLIC __attribute__((visibility("default")))
++#define ATTRIBUTE_NON_NULL __attribute__((nonnull))
++#endif
+ 
+ /* Get Library Target Build Type */
+ #cmakedefine01 BUILD_SHARED_LIBS
+@@ -62,7 +68,7 @@ typedef enum {
+ //      free(installPath); //caller must free allocated memory after usage.
+ //    ...
+ //  }
+-LIB_API_PUBLIC PathErrors_t getROCmInstallPath(char **InstallPath, unsigned int *InstallPathLen) __attribute__((nonnull)) ;
++LIB_API_PUBLIC PathErrors_t getROCmInstallPath(char **InstallPath, unsigned int *InstallPathLen) ATTRIBUTE_NON_NULL ;
+ 
+ #ifdef __cplusplus
+ }  // end extern "C" block
+diff --git a/rocm_version.h.in b/rocm_version.h.in
+index f9c11a9..6c239da 100644
+--- a/rocm_version.h.in
++++ b/rocm_version.h.in
+@@ -33,7 +33,13 @@ extern "C" {
+ #endif  /* __cplusplus */
+ 
+ 
+-#define LIB_API_PUBLIC __attribute__ ((visibility ("default")))
++#if defined(_WIN32) || defined(__CYGWIN__)
++#define LIB_API_PUBLIC __declspec(dllexport)
++#define ATTRIBUTE_NON_NULL
++#else
++#define LIB_API_PUBLIC __attribute__((visibility("default")))
++#define ATTRIBUTE_NON_NULL __attribute__((nonnull))
++#endif
+ 
+ 
+ #define ROCM_VERSION_MAJOR   @VERSION_MAJOR@
+@@ -52,7 +58,7 @@ typedef enum {
+ 
+ //  API for getting the verion
+ //  Return val :  VerErros : API execution status.  The parameters are valid only when the exetution status is SUCCESS==0
+-LIB_API_PUBLIC VerErrors getROCmVersion(unsigned int* Major, unsigned int* Minor, unsigned int* Patch) __attribute__((nonnull)) ;
++LIB_API_PUBLIC VerErrors getROCmVersion(unsigned int* Major, unsigned int* Minor, unsigned int* Patch) ATTRIBUTE_NON_NULL ;
+ //  Usage :
+ //  int mj=0,mn=0,p=0,ret=0;
+ //  ret=getROCMVersion(&mj,&mn,&p);
+-- 
+2.34.1
+


### PR DESCRIPTION
Progress on https://github.com/nod-ai/TheRock/issues/36. Depends on https://github.com/nod-ai/TheRock/pull/43 and https://github.com/nod-ai/TheRock/pull/44 (the first two commits).

This adds a new workflow, triggered as part of ci.yml, that configures and builds a subset of the project.

Future changes will:

* Switch to a more powerful self-hosted runner instead of using standard GitHub-hosted runners (we have some runners but they need some configuration to be able to run the `repo` tool without `SSL: CERTIFICATE_VERIFY_FAILED` errors)
* Build more subprojects (this will patches or upstream changes to each subproject to improve portability)