### PR TITLE
Mirror third-party source archives to a stable location on S3.

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_custom_target(therock-third-party)
+
 # No-dep third party libraries (alphabetical)
 add_subdirectory(boost)
 add_subdirectory(eigen)

--- a/third-party/FunctionalPlus/CMakeLists.txt
+++ b/third-party/FunctionalPlus/CMakeLists.txt
@@ -1,6 +1,7 @@
 therock_subproject_fetch(therock-FunctionalPlus-sources
   CMAKE_PROJECT
-  URL https://github.com/Dobiasd/FunctionalPlus/archive/refs/tags/v0.2.25.tar.gz
+  # Originally mirrored from: https://github.com/Dobiasd/FunctionalPlus/archive/refs/tags/v0.2.25.tar.gz
+  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/FunctionalPlus-0.2.25.tar.gz
   URL_HASH SHA256=9b5e24bbc92f43b977dc83efbc173bcf07dbe07f8718fc2670093655b56fcee3
 )
 
@@ -12,3 +13,5 @@ therock_cmake_subproject_declare(therock-FunctionalPlus
 therock_cmake_subproject_provide_package(
   therock-FunctionalPlus FunctionalPlus lib/cmake/FunctionalPlus)
 therock_cmake_subproject_activate(therock-FunctionalPlus)
+
+add_dependencies(therock-third-party therock-FunctionalPlus)

--- a/third-party/boost/CMakeLists.txt
+++ b/third-party/boost/CMakeLists.txt
@@ -12,9 +12,8 @@ set(_download_stamp "${_source_dir}/download.stamp")
 
 therock_subproject_fetch(boost-sources
   SOURCE_DIR "${_source_dir}"
-  # Note: For some reason the corresponding git repo is hundreds of MB, even
-  # when shallow-fetched. So just use a source snapshot.
-  URL "https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2"
+  # Originally mirrored from: "https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2"
+  URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/boost_1_87_0.tar.bz2"
   URL_HASH "SHA256=af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89"
   TOUCH "${_download_stamp}"
 )
@@ -40,3 +39,5 @@ therock_cmake_subproject_provide_package(therock-boost boost_filesystem "lib/cma
 therock_cmake_subproject_provide_package(therock-boost boost_headers "lib/cmake/boost_headers-${_boost_version}")
 therock_cmake_subproject_provide_package(therock-boost boost_system "lib/cmake/boost_system-${_boost_version}")
 therock_cmake_subproject_activate(therock-boost)
+
+add_dependencies(therock-third-party therock-boost)

--- a/third-party/eigen/CMakeLists.txt
+++ b/third-party/eigen/CMakeLists.txt
@@ -1,6 +1,7 @@
 therock_subproject_fetch(therock-eigen-sources
   CMAKE_PROJECT
-  URL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2
+  # Originally mirrored from: https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2
+  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/eigen-3.4.0.tar.bz2
   URL_HASH SHA256=b4c198460eba6f28d34894e3a5710998818515104d6e74e5cc331ce31e46e626
 )
 
@@ -11,3 +12,5 @@ therock_cmake_subproject_declare(therock-eigen
 )
 therock_cmake_subproject_provide_package(therock-eigen Eigen3 share/eigen3/cmake)
 therock_cmake_subproject_activate(therock-eigen)
+
+add_dependencies(therock-third-party therock-eigen)

--- a/third-party/fmt/CMakeLists.txt
+++ b/third-party/fmt/CMakeLists.txt
@@ -1,6 +1,7 @@
 therock_subproject_fetch(therock-fmt-sources
   CMAKE_PROJECT
-  URL https://github.com/fmtlib/fmt/releases/download/11.1.3/fmt-11.1.3.zip
+  # Originally mirrored from: https://github.com/fmtlib/fmt/releases/download/11.1.3/fmt-11.1.3.zip
+  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/fmt-11.1.3.zip
   URL_HASH SHA256=7df2fd3426b18d552840c071c977dc891efe274051d2e7c47e2c83c3918ba6df
 )
 
@@ -15,3 +16,5 @@ therock_cmake_subproject_declare(therock-fmt
 therock_cmake_subproject_provide_package(
   therock-fmt fmt lib/cmake/fmt)
 therock_cmake_subproject_activate(therock-fmt)
+
+add_dependencies(therock-third-party therock-fmt)

--- a/third-party/frugally-deep/CMakeLists.txt
+++ b/third-party/frugally-deep/CMakeLists.txt
@@ -1,6 +1,7 @@
 therock_subproject_fetch(therock-frugally-deep-sources
   CMAKE_PROJECT
-  URL https://github.com/Dobiasd/frugally-deep/archive/refs/tags/v0.16.2.tar.gz
+  # Originally mirrored from: https://github.com/Dobiasd/frugally-deep/archive/refs/tags/v0.16.2.tar.gz
+  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/frugally-deep-0.16.2.tar.gz
   URL_HASH SHA256=b16af09606dcf02359de53b7c47323baaeda9a174e1c87e126c3127c55571971
 )
 
@@ -16,3 +17,5 @@ therock_cmake_subproject_declare(therock-frugally-deep
 therock_cmake_subproject_provide_package(
   therock-frugally-deep frugally-deep lib/cmake/frugally-deep)
 therock_cmake_subproject_activate(therock-frugally-deep)
+
+add_dependencies(therock-third-party therock-frugally-deep)

--- a/third-party/msgpack-cxx/CMakeLists.txt
+++ b/third-party/msgpack-cxx/CMakeLists.txt
@@ -1,6 +1,7 @@
 therock_subproject_fetch(therock-msgpack-cxx-sources
   CMAKE_PROJECT
-  URL https://github.com/msgpack/msgpack-c/releases/download/cpp-7.0.0/msgpack-cxx-7.0.0.tar.gz
+  # Originally mirrored from: https://github.com/msgpack/msgpack-c/releases/download/cpp-7.0.0/msgpack-cxx-7.0.0.tar.gz
+  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/msgpack-cxx-7.0.0.tar.gz
   URL_HASH SHA256=7504b7af7e7b9002ce529d4f941e1b7fb1fb435768780ce7da4abaac79bb156f
 )
 
@@ -14,3 +15,5 @@ therock_cmake_subproject_declare(therock-msgpack-cxx
 therock_cmake_subproject_provide_package(
   therock-msgpack-cxx msgpack-cxx lib/cmake/msgpack-cxx)
 therock_cmake_subproject_activate(therock-msgpack-cxx)
+
+add_dependencies(therock-third-party therock-msgpack-cxx)

--- a/third-party/nlohmann-json/CMakeLists.txt
+++ b/third-party/nlohmann-json/CMakeLists.txt
@@ -1,6 +1,7 @@
 therock_subproject_fetch(therock-nlohmann-json-sources
   CMAKE_PROJECT
-  URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+  # Originally mirrored from: https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+  URL https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/json-3.11.3.tar.gz
   URL_HASH SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
 )
 

--- a/third-party/nlohmann-json/CMakeLists.txt
+++ b/third-party/nlohmann-json/CMakeLists.txt
@@ -1,7 +1,5 @@
 therock_subproject_fetch(therock-nlohmann-json-sources
   CMAKE_PROJECT
-  # Note: For some reason the corresponding git repo is hundreds of MB, even
-  # when shallow-fetched. So just use a source snapshot.
   URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
   URL_HASH SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
 )
@@ -15,3 +13,5 @@ therock_cmake_subproject_declare(therock-nlohmann-json
 therock_cmake_subproject_provide_package(
   therock-nlohmann-json nlohmann_json share/cmake/nlohmann_json)
 therock_cmake_subproject_activate(therock-nlohmann-json)
+
+add_dependencies(therock-third-party therock-nlohmann-json)


### PR DESCRIPTION
* No hashes were changed.
* Adds a convenience `therock-third-party` target to build all third party libraries.

Fixes #76