### PR TITLE
Skip therock_create_dist() on Windows until all of base builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,4 +240,7 @@ endif()
 # Finalization
 ################################################################################
 therock_subproject_merge_compile_commands()
-therock_create_dist()
+if(NOT WIN32)
+  # TODO(#36): Enable on Windows (base/artifact.toml includes rocm_smi_lib that is excluded on Windows)
+  therock_create_dist()
+endif()


### PR DESCRIPTION
Current errors when building `all`:
```
[build] [1/5  20% :: 0.138] Merging artifact base
[build] FAILED: artifacts/base_dbg/artifact_manifest.txt artifacts/base_dev/artifact_manifest.txt artifacts/base_doc/artifact_manifest.txt artifacts/base_lib/artifact_manifest.txt artifacts/base_run/artifact_manifest.txt artifacts/base_test/artifact_manifest.txt D:/projects/TheRock/build/artifacts/base_dbg/artifact_manifest.txt D:/projects/TheRock/build/artifacts/base_dev/artifact_manifest.txt D:/projects/TheRock/build/artifacts/base_doc/artifact_manifest.txt D:/projects/TheRock/build/artifacts/base_lib/artifact_manifest.txt D:/projects/TheRock/build/artifacts/base_run/artifact_manifest.txt D:/projects/TheRock/build/artifacts/base_test/artifact_manifest.txt 
[build] C:\Windows\system32\cmd.exe /C "cd /D D:\projects\TheRock\build\base && "C:\Program Files\Python312\python.exe" D:/projects/TheRock/build_tools/fileset_tool.py artifact --output-dir D:/projects/TheRock/build/artifacts/base_dbg --root-dir D:/projects/TheRock/build --descriptor D:/projects/TheRock/base/artifact.toml --component dbg --manifest D:/projects/TheRock/build/artifacts/base_dbg/artifact_manifest.txt && "C:\Program Files\Python312\python.exe" D:/projects/TheRock/build_tools/fileset_tool.py artifact --output-dir D:/projects/TheRock/build/artifacts/base_dev --root-dir D:/projects/TheRock/build --descriptor D:/projects/TheRock/base/artifact.toml --component dev --manifest D:/projects/TheRock/build/artifacts/base_dev/artifact_manifest.txt && "C:\Program Files\Python312\python.exe" D:/projects/TheRock/build_tools/fileset_tool.py artifact --output-dir D:/projects/TheRock/build/artifacts/base_doc --root-dir D:/projects/TheRock/build --descriptor D:/projects/TheRock/base/artifact.toml --component doc --manifest D:/projects/TheRock/build/artifacts/base_doc/artifact_manifest.txt && "C:\Program Files\Python312\python.exe" D:/projects/TheRock/build_tools/fileset_tool.py artifact --output-dir D:/projects/TheRock/build/artifacts/base_lib --root-dir D:/projects/TheRock/build --descriptor D:/projects/TheRock/base/artifact.toml --component lib --manifest D:/projects/TheRock/build/artifacts/base_lib/artifact_manifest.txt && "C:\Program Files\Python312\python.exe" D:/projects/TheRock/build_tools/fileset_tool.py artifact --output-dir D:/projects/TheRock/build/artifacts/base_run --root-dir D:/projects/TheRock/build --descriptor D:/projects/TheRock/base/artifact.toml --component run --manifest D:/projects/TheRock/build/artifacts/base_run/artifact_manifest.txt && "C:\Program Files\Python312\python.exe" D:/projects/TheRock/build_tools/fileset_tool.py artifact --output-dir D:/projects/TheRock/build/artifacts/base_test --root-dir D:/projects/TheRock/build --descriptor D:/projects/TheRock/base/artifact.toml --component test --manifest D:/projects/TheRock/build/artifacts/base_test/artifact_manifest.txt"
[build] Traceback (most recent call last):
[build]   File "D:\projects\TheRock\build_tools\fileset_tool.py", line 550, in <module>
[build]     main(sys.argv[1:])
[build]   File "D:\projects\TheRock\build_tools\fileset_tool.py", line 546, in main
[build]     args.func(args)
[proc] The command: "C:\Program Files\CMake\bin\cmake.EXE" --build d:/projects/TheRock/build --config RelWithDebInfo --target all -- exited with code: 1
[build]   File "D:\projects\TheRock\build_tools\fileset_tool.py", line 321, in do_artifact
[build]     pm.add_basedir(basedir)
[build]   File "D:\projects\TheRock\build_tools\fileset_tool.py", line 147, in add_basedir
[build]     scan_children(basedir, "")
[build]   File "D:\projects\TheRock\build_tools\fileset_tool.py", line 136, in scan_children
[build]     with os.scandir(rootpath) as it:
[build]          ^^^^^^^^^^^^^^^^^^^^
[build] FileNotFoundError: [WinError 3] The system cannot find the path specified: 'D:\\projects\\TheRock\\build\\base\\rocm_smi_lib\\stage'
[build] ninja: build stopped: subcommand failed.
```

Due to https://github.com/nod-ai/TheRock/blob/b31d7fe504df415a5d55a481b81cec8ef3afe0f9/base/CMakeLists.txt#L113-L131 https://github.com/nod-ai/TheRock/blob/b31d7fe504df415a5d55a481b81cec8ef3afe0f9/base/artifact.toml#L5-L13

I see that https://github.com/nod-ai/TheRock/pull/79 didn't touch `base/`. Could `rocm_smi_lib` be an optional feature of the base component too?