### PR TITLE
Skip incompatible rocprofiler-systems submodules on Windows.

### DIFF
--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -124,6 +124,9 @@ def populate_ancillary_sources(args):
 
     # TODO(#36): Enable once rocprofiler-systems can be checked out on Windows
     #     error: invalid path 'src/counter_analysis_toolkit/scripts/sample_data/L2_RQSTS:ALL_DEMAND_REFERENCES.data.reads.stat'
+    #  Upstream issues:
+    #   https://github.com/ROCm/rocprofiler-systems/issues/105
+    #   https://github.com/icl-utk-edu/papi/issues/321
     if not is_windows():
         populate_submodules_if_exists(args.dir / "rocprofiler-systems")
 

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -6,6 +6,7 @@
 import argparse
 import os
 from pathlib import Path
+import platform
 import shlex
 import shutil
 import subprocess
@@ -17,6 +18,8 @@ THEROCK_DIR = THIS_SCRIPT_DIR.parent
 DEFAULT_SOURCES_DIR = THEROCK_DIR / "sources"
 PATCHES_DIR = THEROCK_DIR / "patches"
 
+def is_windows() -> bool:
+    return platform.system() == "Windows"
 
 def setup_repo_tool() -> Path:
     """Sets up https://gerrit.googlesource.com/git-repo/, downloading as needed."""
@@ -118,7 +121,11 @@ def populate_ancillary_sources(args):
     step to fixing the underlying software packages."""
     populate_submodules_if_exists(args.dir / "rocprofiler-register")
     populate_submodules_if_exists(args.dir / "rocprofiler-sdk")
-    populate_submodules_if_exists(args.dir / "rocprofiler-systems")
+
+    # TODO(#36): Enable once rocprofiler-systems can be checked out on Windows
+    #     error: invalid path 'src/counter_analysis_toolkit/scripts/sample_data/L2_RQSTS:ALL_DEMAND_REFERENCES.data.reads.stat'
+    if not is_windows():
+        populate_submodules_if_exists(args.dir / "rocprofiler-systems")
 
 
 def populate_submodules_if_exists(git_dir: Path):


### PR DESCRIPTION
Progress on https://github.com/nod-ai/TheRock/issues/36.

This dependency which was added in https://github.com/nod-ai/TheRock/pull/89 contains file paths that are not valid on Windows. Full error logs: https://gist.github.com/ScottTodd/0304483dca863cf6b8b74c15e14dbd85.