### PR TITLE
Patch rocprofiler-register for Windows compatibility and enable.

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -71,8 +71,6 @@ endif()
 # This is a stub that helps runtime libraries and profiles rendezvous
 ################################################################################
 
-if(NOT WIN32)  # TODO(#36): Enable on Windows and/or make subproject inclusion generally optional
-
 therock_cmake_subproject_declare(rocprofiler-register
   EXTERNAL_SOURCE_DIR "rocprofiler-register"
   INTERFACE_LINK_DIRS
@@ -86,8 +84,6 @@ therock_cmake_subproject_glob_c_sources(rocprofiler-register
 therock_cmake_subproject_provide_package(rocprofiler-register
   rocprofiler-register lib/cmake/rocprofiler-register)
 therock_cmake_subproject_activate(rocprofiler-register)
-
-endif()
 
 
 ################################################################################
@@ -114,7 +110,6 @@ set(_optional_subproject_deps)
 if(NOT WIN32)
   # TODO(#36): Enable on Windows and/or make subproject inclusion generally optional
   list(APPEND _optional_subproject_deps rocm_smi_lib)
-  list(APPEND _optional_subproject_deps rocprofiler-register)
 endif()
 
 therock_provide_artifact(base
@@ -132,5 +127,6 @@ therock_provide_artifact(base
     rocm-cmake
     rocm-core
     rocm-half
+    rocprofiler-register
     therock-aux-overlay
 )

--- a/build_tools/patch_symlinks_for_windows_ci.sh
+++ b/build_tools/patch_symlinks_for_windows_ci.sh
@@ -13,13 +13,16 @@ cd ${root_dir}
 rm base/half
 rm base/rocm-cmake
 rm base/rocm-core
+rm base/rocprofiler-register
 
 # Delete .git folders which are symlinks too. CI doesn't need them.
 rm -rf sources/half/.git
 rm -rf sources/rocm-cmake/.git
 rm -rf sources/rocm-core/.git
+rm -rf sources/rocprofiler-register/.git
 
 # Copy from sources/ to where the symlinks were.
 cp -r sources/half base
 cp -r sources/rocm-cmake base
 cp -r sources/rocm-core base
+cp -r sources/rocprofiler-register base

--- a/patches/amd-mainline/rocprofiler-register/0001-Minimally-working-Windows-MSVC-build.patch
+++ b/patches/amd-mainline/rocprofiler-register/0001-Minimally-working-Windows-MSVC-build.patch
@@ -1,0 +1,314 @@
+From c5a00b88a750a1dd2d166211adabfd82ad282528 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Thu, 13 Feb 2025 15:10:48 -0800
+Subject: [PATCH] Minimally working Windows/MSVC build.
+
+---
+ .../include/rocprofiler-register/version.h.in | 10 ++-
+ .../lib/rocprofiler-register/CMakeLists.txt   | 12 ++-
+ .../lib/rocprofiler-register/details/dl.cpp   | 36 +++++----
+ .../lib/rocprofiler-register/details/dl.hpp   | 23 ++++--
+ .../details/environment.hpp                   |  7 +-
+ .../rocprofiler-register/details/utility.cpp  |  1 -
+ .../rocprofiler_register.cpp                  | 73 +++++++++++--------
+ 7 files changed, 103 insertions(+), 59 deletions(-)
+
+diff --git a/source/include/rocprofiler-register/version.h.in b/source/include/rocprofiler-register/version.h.in
+index 7623999..982411c 100644
+--- a/source/include/rocprofiler-register/version.h.in
++++ b/source/include/rocprofiler-register/version.h.in
+@@ -47,7 +47,13 @@
+     ((10000 * ROCPROFILER_REGISTER_VERSION_MAJOR) +                                      \
+      (100 * ROCPROFILER_REGISTER_VERSION_MINOR) + ROCPROFILER_REGISTER_VERSION_PATCH)
+ 
+-#define ROCPROFILER_REGISTER_ATTRIBUTE(...)   __attribute__((__VA_ARGS__))
++#if defined(_WIN32) || defined(__CYGWIN__)
++// TODO: implementations on Windows (e.g. `__declspec(dllexport)`)
++#    define ROCPROFILER_REGISTER_ATTRIBUTE(...)
++#else
++#    define ROCPROFILER_REGISTER_ATTRIBUTE(...) __attribute__((__VA_ARGS__))
++#endif
++
+ #define ROCPROFILER_REGISTER_PP_COMBINE(X, Y) X##Y
+ 
+ #if defined(rocprofiler_register_EXPORTS)
+@@ -86,7 +92,7 @@
+ #    endif
+ 
+ #    define ROCPROFILER_REGISTER_STRINGIZE(X)  ROCPROFILER_REGISTER_STRINGIZE2(X)
+-#    define ROCPROFILER_REGISTER_STRINGIZE2(X) #    X
++#    define ROCPROFILER_REGISTER_STRINGIZE2(X) #X
+ #    define ROCPROFILER_REGISTER_LINESTR       ROCPROFILER_REGISTER_STRINGIZE(__LINE__)
+ #    define ROCPROFILER_REGISTER_ESC(...)      __VA_ARGS__
+ 
+diff --git a/source/lib/rocprofiler-register/CMakeLists.txt b/source/lib/rocprofiler-register/CMakeLists.txt
+index 840fbed..b5da033 100644
+--- a/source/lib/rocprofiler-register/CMakeLists.txt
++++ b/source/lib/rocprofiler-register/CMakeLists.txt
+@@ -17,12 +17,20 @@ target_include_directories(
+     rocprofiler-register PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/source
+                                  ${PROJECT_BINARY_DIR}/source)
+ 
++
++set(_optional_deps)
++if(NOT WIN32)
++    list(APPEND _optional_deps rocprofiler-register::dl)
++    list(APPEND _optional_deps rocprofiler-register::stdcxxfs)
++else()
++endif()
++
+ target_link_libraries(
+     rocprofiler-register
+     PUBLIC rocprofiler-register::headers
+     PRIVATE fmt::fmt glog::glog rocprofiler-register::build-flags
+-            rocprofiler-register::memcheck rocprofiler-register::stdcxxfs
+-            rocprofiler-register::dl)
++            rocprofiler-register::memcheck
++            ${_optional_deps})
+ 
+ set_target_properties(
+     rocprofiler-register
+diff --git a/source/lib/rocprofiler-register/details/dl.cpp b/source/lib/rocprofiler-register/details/dl.cpp
+index a497dd3..fc2f898 100644
+--- a/source/lib/rocprofiler-register/details/dl.cpp
++++ b/source/lib/rocprofiler-register/details/dl.cpp
+@@ -20,23 +20,29 @@
+ // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ // SOFTWARE.
+ 
+-#define GNU_SOURCE 1
++#if defined(_WIN32) || defined(__CYGWIN__)
+ 
+-#include "dl.hpp"
+-#include "filesystem.hpp"
+-#include "utility.hpp"
++// TODO: implement for Windows
+ 
+-#include <fstream>
+-#include <optional>
+-#include <string>
+-#include <string_view>
++#else
+ 
+-#include <dlfcn.h>
+-#include <elf.h>
+-#include <fmt/core.h>
+-#include <link.h>
+-#include <sys/types.h>
+-#include <unistd.h>
++#    define GNU_SOURCE 1
++
++#    include "dl.hpp"
++#    include "filesystem.hpp"
++#    include "utility.hpp"
++
++#    include <fstream>
++#    include <optional>
++#    include <string>
++#    include <string_view>
++
++#    include <dlfcn.h>
++#    include <elf.h>
++#    include <fmt/core.h>
++#    include <link.h>
++#    include <sys/types.h>
++#    include <unistd.h>
+ 
+ namespace rocprofiler_register
+ {
+@@ -120,3 +126,5 @@ get_linked_path(std::string_view _name, open_modes_vec_t&& _open_modes)
+ }
+ }  // namespace binary
+ }  // namespace rocprofiler_register
++
++#endif  // defined(_WIN32) || defined(__CYGWIN__)
+diff --git a/source/lib/rocprofiler-register/details/dl.hpp b/source/lib/rocprofiler-register/details/dl.hpp
+index bfded01..9cd316f 100644
+--- a/source/lib/rocprofiler-register/details/dl.hpp
++++ b/source/lib/rocprofiler-register/details/dl.hpp
+@@ -22,15 +22,20 @@
+ 
+ #pragma once
+ 
+-#include <cstdint>
+-#include <optional>
+-#include <string>
+-#include <string_view>
+-#include <vector>
++#if defined(_WIN32) || defined(__CYGWIN__)
+ 
+-#include <dlfcn.h>
+-#include <sys/types.h>
+-#include <unistd.h>
++// TODO: implement for Windows
++
++#else
++
++#    include <cstdint>
++#    include <optional>
++#    include <string>
++#    include <string_view>
++#    include <vector>
++
++#    include <sys/types.h>
++#    include <unistd.h>
+ 
+ namespace rocprofiler_register
+ {
+@@ -58,3 +63,5 @@ std::optional<std::string>
+ get_linked_path(std::string_view, open_modes_vec_t&& = {});
+ }  // namespace binary
+ }  // namespace rocprofiler_register
++
++#endif  // defined(_WIN32) || defined(__CYGWIN__)
+diff --git a/source/lib/rocprofiler-register/details/environment.hpp b/source/lib/rocprofiler-register/details/environment.hpp
+index 4250ed4..7219214 100644
+--- a/source/lib/rocprofiler-register/details/environment.hpp
++++ b/source/lib/rocprofiler-register/details/environment.hpp
+@@ -23,7 +23,7 @@
+ #include "fmt/core.h"
+ #include "glog/logging.h"
+ 
+-#include <unistd.h>
++#include <stdlib.h>
+ #include <cstdio>
+ #include <cstdlib>
+ #include <cstring>
+@@ -135,7 +135,12 @@ struct env_config
+         if(env_name.empty()) return -1;
+         LOG(INFO) << fmt::format(
+             "setenv({}, {}, {})", env_name.c_str(), env_value.c_str(), override);
++#if defined(_WIN32) || defined(__CYGWIN__)
++        // TODO: Windows implementation?
++        return -1;
++#else
+         return setenv(env_name.c_str(), env_value.c_str(), override);
++#endif
+     }
+ };
+ }  // namespace common
+diff --git a/source/lib/rocprofiler-register/details/utility.cpp b/source/lib/rocprofiler-register/details/utility.cpp
+index cc9e9fc..930d542 100644
+--- a/source/lib/rocprofiler-register/details/utility.cpp
++++ b/source/lib/rocprofiler-register/details/utility.cpp
+@@ -26,7 +26,6 @@
+ #include <string_view>
+ 
+ #include <sys/types.h>
+-#include <unistd.h>
+ 
+ namespace rocprofiler_register
+ {
+diff --git a/source/lib/rocprofiler-register/rocprofiler_register.cpp b/source/lib/rocprofiler-register/rocprofiler_register.cpp
+index 0905edd..dd79655 100644
+--- a/source/lib/rocprofiler-register/rocprofiler_register.cpp
++++ b/source/lib/rocprofiler-register/rocprofiler_register.cpp
+@@ -36,19 +36,26 @@
+ #include <string_view>
+ #include <utility>
+ 
+-#include <dlfcn.h>
+-
+-extern "C" {
+-#pragma weak rocprofiler_configure
+-#pragma weak rocprofiler_set_api_table
+-#pragma weak rocprofiler_register_import_hip
+-#pragma weak rocprofiler_register_import_hip_static
+-#pragma weak rocprofiler_register_import_hip_compiler
+-#pragma weak rocprofiler_register_import_hip_compiler_static
+-#pragma weak rocprofiler_register_import_hsa
+-#pragma weak rocprofiler_register_import_hsa_static
+-#pragma weak rocprofiler_register_import_roctx
+-#pragma weak rocprofiler_register_import_roctx_static
++#if defined(_WIN32) || defined(__CYGWIN__)
++
++// TODO: Do something sensible on Windows (at least implement APIs with no-ops)
++
++#else
++
++#    include <dlfcn.h>
++
++extern "C"
++{
++#    pragma weak rocprofiler_configure
++#    pragma weak rocprofiler_set_api_table
++#    pragma weak rocprofiler_register_import_hip
++#    pragma weak rocprofiler_register_import_hip_static
++#    pragma weak rocprofiler_register_import_hip_compiler
++#    pragma weak rocprofiler_register_import_hip_compiler_static
++#    pragma weak rocprofiler_register_import_hsa
++#    pragma weak rocprofiler_register_import_hsa_static
++#    pragma weak rocprofiler_register_import_roctx
++#    pragma weak rocprofiler_register_import_roctx_static
+ 
+ extern rocprofiler_tool_configure_result_t*
+ rocprofiler_configure(uint32_t, const char*, uint32_t, rocprofiler_client_id_t*);
+@@ -124,23 +131,23 @@ struct supported_library_trait
+ template <size_t Idx>
+ struct rocp_reg_error_message;
+ 
+-#define ROCP_REG_DEFINE_LIBRARY_TRAITS(ENUM, NAME, SYM_NAME, LIB_NAME)                   \
+-    template <>                                                                          \
+-    struct supported_library_trait<ENUM>                                                 \
+-    {                                                                                    \
+-        static constexpr bool specialized  = true;                                       \
+-        static constexpr auto value        = ENUM;                                       \
+-        static constexpr auto common_name  = NAME;                                       \
+-        static constexpr auto symbol_name  = SYM_NAME;                                   \
+-        static constexpr auto library_name = LIB_NAME;                                   \
+-    };
++#    define ROCP_REG_DEFINE_LIBRARY_TRAITS(ENUM, NAME, SYM_NAME, LIB_NAME)               \
++        template <>                                                                      \
++        struct supported_library_trait<ENUM>                                             \
++        {                                                                                \
++            static constexpr bool specialized  = true;                                   \
++            static constexpr auto value        = ENUM;                                   \
++            static constexpr auto common_name  = NAME;                                   \
++            static constexpr auto symbol_name  = SYM_NAME;                               \
++            static constexpr auto library_name = LIB_NAME;                               \
++        };
+ 
+-#define ROCP_REG_DEFINE_ERROR_MESSAGE(ENUM, MSG)                                         \
+-    template <>                                                                          \
+-    struct rocp_reg_error_message<ENUM>                                                  \
+-    {                                                                                    \
+-        static constexpr auto value = MSG;                                               \
+-    };
++#    define ROCP_REG_DEFINE_ERROR_MESSAGE(ENUM, MSG)                                     \
++        template <>                                                                      \
++        struct rocp_reg_error_message<ENUM>                                              \
++        {                                                                                \
++            static constexpr auto value = MSG;                                           \
++        };
+ 
+ ROCP_REG_DEFINE_LIBRARY_TRAITS(ROCP_REG_HSA,
+                                "hsa",
+@@ -228,7 +235,8 @@ struct rocp_import
+ };
+ 
+ template <size_t... Idx>
+-auto rocp_reg_get_imports(std::index_sequence<Idx...>)
++auto
++rocp_reg_get_imports(std::index_sequence<Idx...>)
+ {
+     auto _data        = std::vector<rocp_import>{};
+     auto _import_scan = [&_data](auto _info) {
+@@ -361,7 +369,8 @@ auto           import_info       = rocp_reg_get_imports(library_seq);
+ auto           instance_counters = std::array<std::atomic_uint64_t, ROCP_REG_LAST>{};
+ }  // namespace
+ 
+-extern "C" {
++extern "C"
++{
+ rocprofiler_register_error_code_t
+ rocprofiler_register_library_api_table(
+     const char*                                 common_name,
+@@ -469,3 +478,5 @@ rocprofiler_register_error_string(rocprofiler_register_error_code_t _ec)
+         _ec, std::make_index_sequence<ROCP_REG_ERROR_CODE_END>{});
+ }
+ }
++
++#endif  // defined(_WIN32) || defined(__CYGWIN__)
+-- 
+2.47.1.windows.2
+


### PR DESCRIPTION
Progress on https://github.com/nod-ai/TheRock/issues/36.

This is gross, and the odd [`.clang-format`](https://github.com/ROCm/rocprofiler-register/blob/amd-staging/.clang-format) file in the rocprofiler-register repo isn't helping. There are probably better design patterns for no-oping the entire project or adding proper support for multiple platforms.

I hacked around enough to get a CMake configure + build that produces a 50KB `rocprofiler-register.dll` on Windows using MSVC and a default CMake build on the default branch from GitHub (standalone, outside of TheRock). The DLL is not expected to work since it is missing function definitions and I did not implement Windows-specific versions of the functions, but this unblocks more parts of build in this project that depend on rocprofiler-register.

I did no testing on Linux, relying on our CI builds here for that. Hopefully I didn't break anything.