### PR TITLE
Enable compiler subprojects on Windows.

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -64,10 +64,15 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu \
             -DTHEROCK_PACKAGE_VERSION="${package_version}" \
+            -DTHEROCK_ENABLE_COMPILER=ON \
             -DTHEROCK_ENABLE_CORE=OFF \
+            -DTHEROCK_ENABLE_CORE_RUNTIME=OFF \
             -DTHEROCK_ENABLE_COMM_LIBS=OFF \
             -DTHEROCK_ENABLE_MATH_LIBS=OFF \
-            -DTHEROCK_ENABLE_ML_LIBS=OFF
+            -DTHEROCK_ENABLE_ML_LIBS=OFF \
+            -DTHEROCK_ENABLE_HIPIFY=OFF \
+            -DTHEROCK_ENABLE_HIP_RUNTIME=OFF \
+            -DTHEROCK_ENABLE_PROFILER_SDK=OFF
 
       - name: Build Projects
         run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,7 @@ if(NOT WIN32)
   add_subdirectory(ml-libs)
 else()
   # TODO(#36): Enable more project builds on Windows and/or make the full list configurable.
+  add_subdirectory(compiler)
 endif()
 
 add_subdirectory(examples)

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -63,6 +63,12 @@ if(THEROCK_ENABLE_COMPILER)
   # runtime.
   ##############################################################################
 
+  if(WIN32)
+    set(_link_dylib "OFF")
+  else()
+    set(_link_dylib "ON")
+  endif()
+
   therock_cmake_subproject_declare(amd-comgr
     EXTERNAL_SOURCE_DIR "amd-llvm/amd/comgr"
     BINARY_DIR "amd-comgr"
@@ -70,7 +76,7 @@ if(THEROCK_ENABLE_COMPILER)
     CMAKE_ARGS
       # TODO: Currently unstable. Enable in >6.4.
       -DCOMGR_DISABLE_SPIRV=ON
-      -DLLVM_LINK_LLVM_DYLIB=ON
+      -DLLVM_LINK_LLVM_DYLIB=${_link_dylib}
       # The comgr tests have a circular dependency on the HIP runtime.
       # https://github.com/nod-ai/TheRock/issues/67
       -DBUILD_TESTING=OFF

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -63,12 +63,6 @@ if(THEROCK_ENABLE_COMPILER)
   # runtime.
   ##############################################################################
 
-  if(WIN32)
-    set(_link_dylib "OFF")
-  else()
-    set(_link_dylib "ON")
-  endif()
-
   therock_cmake_subproject_declare(amd-comgr
     EXTERNAL_SOURCE_DIR "amd-llvm/amd/comgr"
     BINARY_DIR "amd-comgr"
@@ -76,10 +70,6 @@ if(THEROCK_ENABLE_COMPILER)
     CMAKE_ARGS
       # TODO: Currently unstable. Enable in >6.4.
       -DCOMGR_DISABLE_SPIRV=ON
-      -DLLVM_LINK_LLVM_DYLIB=${_link_dylib}
-      # The comgr tests have a circular dependency on the HIP runtime.
-      # https://github.com/nod-ai/TheRock/issues/67
-      -DBUILD_TESTING=OFF
     BUILD_DEPS
       rocm-cmake
     RUNTIME_DEPS

--- a/compiler/pre_hook_amd-comgr.cmake
+++ b/compiler/pre_hook_amd-comgr.cmake
@@ -1,0 +1,9 @@
+if(WIN32)
+  set(LLVM_LINK_LLVM_DYLIB OFF)
+else()
+  set(LLVM_LINK_LLVM_DYLIB ON)
+endif()
+
+# The comgr tests have a circular dependency on the HIP runtime.
+# https://github.com/nod-ai/TheRock/issues/67
+set(BUILD_TESTING OFF CACHE BOOL "DISABLE BUILDING TESTS IN SUBPROJECTS" FORCE)

--- a/compiler/pre_hook_amd-llvm.cmake
+++ b/compiler/pre_hook_amd-llvm.cmake
@@ -5,14 +5,25 @@ include("${ROCM_GIT_DIR}/llvm-project/cmake/Modules/LLVMVersion.cmake")
 # Note that in LLVM "BUILD_SHARED_LIBS" enables an unsupported development mode.
 # The flag you want for a shared library build is LLVM_BUILD_LLVM_DYLIB.
 set(BUILD_SHARED_LIBS OFF)
-set(LLVM_BUILD_LLVM_DYLIB ON)
-set(LLVM_LINK_LLVM_DYLIB ON)
-set(LLVM_ENABLE_LIBCXX ON)
+if(WIN32)
+  set(LLVM_BUILD_LLVM_DYLIB OFF)
+  set(LLVM_LINK_LLVM_DYLIB OFF)
+  set(LIBUNWIND_ENABLE_SHARED OFF)
+  set(LIBUNWIND_ENABLE_STATIC ON)
+  # TODO(#36): Enable libunwind, libcxx, and libcxxabi on Windows?
+  #     Should they be supported? What depends on them?
+  set(LLVM_ENABLE_LIBCXX OFF)
+  set(LLVM_ENABLE_RUNTIMES "compiler-rt" CACHE STRING "Enabled runtimes" FORCE)
+else()
+  set(LLVM_BUILD_LLVM_DYLIB ON)
+  set(LLVM_LINK_LLVM_DYLIB ON)
+  set(LLVM_ENABLE_LIBCXX ON)
+  set(LLVM_ENABLE_RUNTIMES "compiler-rt;libunwind;libcxx;libcxxabi" CACHE STRING "Enabled runtimes" FORCE)
+endif()
 
 # Set the LLVM_ENABLE_PROJECTS variable before including LLVM's CMakeLists.txt
 set(BUILD_TESTING OFF CACHE BOOL "DISABLE BUILDING TESTS IN SUBPROJECTS" FORCE)
 set(LLVM_ENABLE_PROJECTS "clang;lld;clang-tools-extra" CACHE STRING "Enable LLVM projects" FORCE)
-set(LLVM_ENABLE_RUNTIMES "compiler-rt;libunwind;libcxx;libcxxabi" CACHE STRING "Enabled runtimes" FORCE)
 set(LLVM_TARGETS_TO_BUILD "AMDGPU;X86" CACHE STRING "Enable LLVM Targets" FORCE)
 
 # Packaging.

--- a/patches/amd-mainline/llvm-project/0001-Enable-MSVC-support-in-comgr.patch
+++ b/patches/amd-mainline/llvm-project/0001-Enable-MSVC-support-in-comgr.patch
@@ -1,0 +1,30 @@
+From 20b027cca8ce5d1cc816d2ecbf2150ce811cc3f0 Mon Sep 17 00:00:00 2001
+From: Scott <scott.todd0@gmail.com>
+Date: Fri, 14 Feb 2025 15:22:48 -0800
+Subject: [PATCH] Enable MSVC support in comgr.
+
+---
+ amd/comgr/CMakeLists.txt | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/amd/comgr/CMakeLists.txt b/amd/comgr/CMakeLists.txt
+index ed01d21cea30..e643256f2a89 100644
+--- a/amd/comgr/CMakeLists.txt
++++ b/amd/comgr/CMakeLists.txt
+@@ -228,7 +228,12 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     "/wd4624" #[[Suppress 'derived class' : destructor could not be generated because a base class destructor is inaccessible]]
+     "/wd4267" #[[Suppress 'var' : conversion from 'size_t' to 'type', possible loss of data]]
+     "/wd4291" #[[Suppress 'declaration' : no matching operator delete found; memory will not be freed if initialization throws an exception]]
+-    "/wd4146" #[[Suppress 'unary minus operator applied to unsigned type, result still unsigned]])
++    "/wd4146" #[[Suppress 'unary minus operator applied to unsigned type, result still unsigned]]
++
++    # Enable standards-conforming preprocessor.
++    # https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor
++    "/Zc:preprocessor"
++  )
+   list(APPEND AMD_COMGR_PRIVATE_COMPILE_DEFINITIONS _HAS_EXCEPTIONS=0)
+ endif()
+ 
+-- 
+2.45.1.windows.1
+


### PR DESCRIPTION
Progress on https://github.com/nod-ai/TheRock/issues/36.

We'll want to switch to self-hosted runners and tune the cache to make the build faster soon. This is still under 20 minutes on standard runners though: https://github.com/nod-ai/TheRock/actions/runs/13339298280/job/37260996314.