### PR TITLE
Get Credentials Working on Windows ARC runners

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -40,7 +40,7 @@ jobs:
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
           # Do this within bash.
-          python -m pip install pip-system-certs certifi python-certifi-win32
+          python -m pip install pip-system-certs --use-feature=truststore
           # Use right credential store https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
           #git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
           # Use windows storage backend.

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -41,7 +41,9 @@ jobs:
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
-          git config --global http.sslBackend schannel
+          # https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
+          git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
+          #git config --global http.sslBackend schannel
           python ./build_tools/fetch_sources.py --depth 1
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -36,7 +36,7 @@ jobs:
         run: choco install ninja --yes
 
       - name: Install Certs (ensure done outside of shell before fetching sources)
-        run: python -m pip install certifi
+        run: python -m pip install -upgrade certifi
 
       - name: Fetch sources
         run: |

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -35,16 +35,12 @@ jobs:
       - name: Install ninja
         run: choco install ninja --yes
 
-        # Is this still necessary?
-      - name: Install certificates
-        run: python -m pip install pip-system-certs certifi python-certifi-win32
-
       - name: Fetch sources
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
           # Do this within bash.
-          pip install --upgrade certifi
+          python -m pip install pip-system-certs certifi python-certifi-win32
           # Use right credential store https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
           #git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
           # Use windows storage backend.

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
+          git config --global http.sslBackend schannel
           python ./build_tools/fetch_sources.py --depth 1
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install ninja
         run: choco install ninja --yes
 
+      - name: Install certificates
+        run: python -m pip install pip-system-certs certifi python-certifi-win32
+
       - name: Fetch sources
         run: |
           git config --global user.email "nobody@amd.com"

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build_windows_packages:
     name: Build Windows Packages
-    runs-on: windows-2022  # TODO(#36): move to cluster of CPU builders like `azure-windows-scale-nod-ai`
+    runs-on: azure-windows-scale-nod-ai
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -35,15 +35,17 @@ jobs:
       - name: Install ninja
         run: choco install ninja --yes
 
-      - name: Install Certs (ensure path is updated if already installed)
+      - name: Install Certs
         run: python -m pip install certifi
 
       - name: Fetch sources
         run: |
+          # Sets an env variable to ensure urllib3 uses the certifi CA bundle in fetch_sources.py.
           export SSL_CERT_FILE=$(python3 -m certifi)
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"          
           python ./build_tools/fetch_sources.py --depth 1
+
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies
         run: ./build_tools/patch_symlinks_for_windows_ci.sh

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -35,13 +35,14 @@ jobs:
       - name: Install ninja
         run: choco install ninja --yes
 
-      - name: Install Certs (ensure done outside of shell before fetching sources)
+      - name: Install Certs (ensure path is updated if already installed)
         run: python -m pip install --upgrade certifi
 
       - name: Fetch sources
         run: |
+          export SSL_CERT_FILE=$(python3 -m certifi)
           git config --global user.email "nobody@amd.com"
-          git config --global user.name "Nobody"
+          git config --global user.name "Nobody"          
           python ./build_tools/fetch_sources.py --depth 1
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -24,7 +24,10 @@ jobs:
       fail-fast: true
     steps:
       - name: Enabling git symlinks
-        run: git config --global core.symlinks true
+        run: |
+          git config --global core.symlinks true
+          git clone https://github.com/amd-chrissosa/emptyrepo.git
+
       - name: "Checking out repository"
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
@@ -41,9 +44,10 @@ jobs:
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
-          # https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
+          # Use right credential store https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
           git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
-          #git config --global http.sslBackend schannel
+          # Use windows storage backend.
+          git config --global http.sslBackend schannel
           python ./build_tools/fetch_sources.py --depth 1
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -24,9 +24,7 @@ jobs:
       fail-fast: true
     steps:
       - name: Enabling git symlinks
-        run: |
-          git config --global core.symlinks true
-          git clone https://github.com/amd-chrissosa/emptyrepo.git
+        run: git config --global core.symlinks true
 
       - name: "Checking out repository"
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
@@ -37,6 +35,7 @@ jobs:
       - name: Install ninja
         run: choco install ninja --yes
 
+        # Is this still necessary?
       - name: Install certificates
         run: python -m pip install pip-system-certs certifi python-certifi-win32
 
@@ -44,10 +43,12 @@ jobs:
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
+          # Do this within bash.
+          pip install --upgrade certifi
           # Use right credential store https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
-          git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
+          #git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
           # Use windows storage backend.
-          git config --global http.sslBackend schannel
+          #git config --global http.sslBackend schannel
           python ./build_tools/fetch_sources.py --depth 1
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Fetch sources
         run: |
-          # Sets an env variable to ensure urllib3 uses the certifi CA bundle in fetch_sources.py.
+          # Sets an env variable to ensure urllib uses the certifi CA bundle in fetch_sources.py.
           export SSL_CERT_FILE=$(python3 -m certifi)
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"          

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -35,12 +35,13 @@ jobs:
       - name: Install ninja
         run: choco install ninja --yes
 
+      - name: Install Certs (ensure done outside of shell before fetching sources)
+        run: python -m pip install pip-system-certs --use-feature=truststore
+
       - name: Fetch sources
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
-          # Do this within bash.
-          python -m pip install pip-system-certs --use-feature=truststore
           # Use right credential store https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
           #git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
           # Use windows storage backend.

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -36,16 +36,12 @@ jobs:
         run: choco install ninja --yes
 
       - name: Install Certs (ensure done outside of shell before fetching sources)
-        run: python -m pip install pip-system-certs --use-feature=truststore
+        run: python -m pip install certifi
 
       - name: Fetch sources
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
-          # Use right credential store https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
-          #git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
-          # Use windows storage backend.
-          #git config --global http.sslBackend schannel
           python ./build_tools/fetch_sources.py --depth 1
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -43,7 +43,7 @@ jobs:
           # Sets an env variable to ensure urllib uses the certifi CA bundle in fetch_sources.py.
           export SSL_CERT_FILE=$(python3 -m certifi)
           git config --global user.email "nobody@amd.com"
-          git config --global user.name "Nobody"          
+          git config --global user.name "Nobody"
           python ./build_tools/fetch_sources.py --depth 1
 
       # TODO(scotttodd): Get symlinks working on CI runners instead of this

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -36,7 +36,7 @@ jobs:
         run: choco install ninja --yes
 
       - name: Install Certs (ensure done outside of shell before fetching sources)
-        run: python -m pip install -upgrade certifi
+        run: python -m pip install --upgrade certifi
 
       - name: Fetch sources
         run: |

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -36,7 +36,7 @@ jobs:
         run: choco install ninja --yes
 
       - name: Install Certs (ensure path is updated if already installed)
-        run: python -m pip install --upgrade certifi
+        run: python -m pip install certifi
 
       - name: Fetch sources
         run: |


### PR DESCRIPTION
Took a bit of trial and error on this one, but the key thing wasn't git not working correctly but the nested urllib.request in fetch_sources.py not pulling in the right cert even after installing certifi. I fix this by manually exporting the cert into the environment based on a suggestion from here: https://stackoverflow.com/questions/77442172/ssl-certificate-verify-failed-certificate-verify-failed-unable-to-get-local-is.

Verified that the repo gets checked out but CL is blocked on CCache error.

Latest run is here: https://github.com/nod-ai/TheRock/actions/runs/13408746108/job/37453832855