### PR TITLE
Move build_windows_packages to self-hosted runner cluster.

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -59,6 +59,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@53911442209d5c18de8a31615e0923161e435875 # v1.2.16
         with:
           key: windows-build-packages-v1
+          create-symlink: true
 
       - name: Configure Projects
         run: |

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -101,11 +101,12 @@ jobs:
       - name: Build Projects
         run: cmake --build "${{ env.BUILD_DIR_BASH }}"
 
-      - name: "Clean up build dir"
-        if: always()
-        run: if (Test-Path -Path "$Env:BUILD_DIR_POWERSHELL") {Remove-Item -Path "$Env:BUILD_DIR_POWERSHELL" -Recurse -Force}
-
       - name: Report
         if: ${{ !cancelled() }}
         run: |
-          ls -lh build
+          ls -lh "${{ env.BUILD_DIR_BASH }}"
+
+      - name: "Clean up build dir"
+        if: always()
+        run: if (Test-Path -Path "$Env:BUILD_DIR_POWERSHELL") {Remove-Item -Path "$Env:BUILD_DIR_POWERSHELL" -Recurse -Force}
+  

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -17,12 +17,25 @@ jobs:
   build_windows_packages:
     name: Build Windows Packages
     runs-on: azure-windows-scale-nod-ai
+    env:
+      BASE_BUILD_DIR_POWERSHELL: "C:\mnt\azure\b"
     defaults:
       run:
         shell: bash
     strategy:
       fail-fast: true
     steps:
+      - name: "Create build dir"
+          run: |
+            $currentTime = (Get-Date).ToString('HHmmss')
+            $buildDir = "$env:BASE_BUILD_DIR_POWERSHELL\$currentTime"
+            echo "BUILD_DIR_POWERSHELL=$buildDir" >> $env:GITHUB_ENV
+            mkdir "$buildDir"
+            Write-Host "Generated Build Directory: $buildDir"
+            $bashBuildDir = $buildDir -replace '\\', '/' -replace '^C:', '/c'
+            echo  "BUILD_DIR_BASH=$bashBuildDir" >> $env:GITHUB_ENV
+            Write-Host "Converted Build Directory For Bash: $bashBuildDir"
+
       - name: Enabling git symlinks
         run: git config --global core.symlinks true
 
@@ -70,7 +83,7 @@ jobs:
           echo "Building package ${package_version}"
 
           # Build.
-          cmake -B build -GNinja . \
+          cmake -B "${{ $bashBuildDir }}" -GNinja . \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu \
             -DTHEROCK_PACKAGE_VERSION="${package_version}" \
@@ -85,7 +98,11 @@ jobs:
             -DTHEROCK_ENABLE_PROFILER_SDK=OFF
 
       - name: Build Projects
-        run: cmake --build build
+        run: cmake --build "${{ $bashBuildDir }}" build
+
+      - name: "Clean up build dir"
+        if: always()
+        run: if (Test-Path -Path "$Env:BUILD_DIR_POWERSHELL") {Remove-Item -Path "$Env:BUILD_DIR_POWERSHELL" -Recurse -Force}
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -40,7 +40,7 @@ jobs:
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
           # Do this within bash.
-          python -m pip install pip-system-certs certifi python-certifi-win32
+          python -m pip install pip-system-certs --use-feature=truststore
           # Use right credential store https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
           #git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
           # Use windows storage backend.

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -41,7 +41,9 @@ jobs:
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
-          git config --global http.sslBackend schannel
+          # https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
+          git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
+          #git config --global http.sslBackend schannel
           python ./build_tools/fetch_sources.py --depth 1
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -36,7 +36,7 @@ jobs:
         run: choco install ninja --yes
 
       - name: Install Certs (ensure done outside of shell before fetching sources)
-        run: python -m pip install certifi
+        run: python -m pip install -upgrade certifi
 
       - name: Fetch sources
         run: |

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -35,16 +35,12 @@ jobs:
       - name: Install ninja
         run: choco install ninja --yes
 
-        # Is this still necessary?
-      - name: Install certificates
-        run: python -m pip install pip-system-certs certifi python-certifi-win32
-
       - name: Fetch sources
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
           # Do this within bash.
-          pip install --upgrade certifi
+          python -m pip install pip-system-certs certifi python-certifi-win32
           # Use right credential store https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
           #git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
           # Use windows storage backend.

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
+          git config --global http.sslBackend schannel
           python ./build_tools/fetch_sources.py --depth 1
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build Windows Packages
     runs-on: azure-windows-scale-nod-ai
     env:
-      BASE_BUILD_DIR_POWERSHELL: "C:\mnt\azure\b"
+      BASE_BUILD_DIR_POWERSHELL: C:\mnt\azure\b
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -109,4 +109,5 @@ jobs:
       - name: "Clean up build dir"
         if: always()
         run: if (Test-Path -Path "$Env:BUILD_DIR_POWERSHELL") {Remove-Item -Path "$Env:BUILD_DIR_POWERSHELL" -Recurse -Force}
+        shell: powershell
   

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install ninja
         run: choco install ninja --yes
 
+      - name: Install certificates
+        run: python -m pip install pip-system-certs certifi python-certifi-win32
+
       - name: Fetch sources
         run: |
           git config --global user.email "nobody@amd.com"

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build_windows_packages:
     name: Build Windows Packages
-    runs-on: windows-2022  # TODO(#36): move to cluster of CPU builders like `azure-windows-scale-nod-ai`
+    runs-on: azure-windows-scale-nod-ai
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -99,7 +99,7 @@ jobs:
             -DTHEROCK_ENABLE_PROFILER_SDK=OFF
 
       - name: Build Projects
-        run: cmake --build "${{ env.BUILD_DIR_BASH }}" build
+        run: cmake --build "${{ env.BUILD_DIR_BASH }}"
 
       - name: "Clean up build dir"
         if: always()

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -35,15 +35,17 @@ jobs:
       - name: Install ninja
         run: choco install ninja --yes
 
-      - name: Install Certs (ensure path is updated if already installed)
+      - name: Install Certs
         run: python -m pip install certifi
 
       - name: Fetch sources
         run: |
+          # Sets an env variable to ensure urllib3 uses the certifi CA bundle in fetch_sources.py.
           export SSL_CERT_FILE=$(python3 -m certifi)
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"          
           python ./build_tools/fetch_sources.py --depth 1
+
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies
         run: ./build_tools/patch_symlinks_for_windows_ci.sh

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -56,10 +56,12 @@ jobs:
       # TODO: We shouldn't be using a cache on actual release branches, but it
       # really helps for iteration time.
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@53911442209d5c18de8a31615e0923161e435875 # v1.2.16
-        with:
-          key: windows-build-packages-v1
-          create-symlink: true
+        run: choco install ccache --yes
+      # TODO: CCache via this action doesn't work. Maybe related to
+      # https://github.com/hendrikmuhs/ccache-action/issues/184
+      #   uses: hendrikmuhs/ccache-action@53911442209d5c18de8a31615e0923161e435875 # v1.2.16
+      #   with:
+      #     key: windows-build-packages-v1
 
       - name: Configure Projects
         run: |

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -35,13 +35,14 @@ jobs:
       - name: Install ninja
         run: choco install ninja --yes
 
-      - name: Install Certs (ensure done outside of shell before fetching sources)
+      - name: Install Certs (ensure path is updated if already installed)
         run: python -m pip install --upgrade certifi
 
       - name: Fetch sources
         run: |
+          export SSL_CERT_FILE=$(python3 -m certifi)
           git config --global user.email "nobody@amd.com"
-          git config --global user.name "Nobody"
+          git config --global user.name "Nobody"          
           python ./build_tools/fetch_sources.py --depth 1
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -24,7 +24,10 @@ jobs:
       fail-fast: true
     steps:
       - name: Enabling git symlinks
-        run: git config --global core.symlinks true
+        run: |
+          git config --global core.symlinks true
+          git clone https://github.com/amd-chrissosa/emptyrepo.git
+
       - name: "Checking out repository"
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
@@ -41,9 +44,10 @@ jobs:
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
-          # https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
+          # Use right credential store https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
           git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
-          #git config --global http.sslBackend schannel
+          # Use windows storage backend.
+          git config --global http.sslBackend schannel
           python ./build_tools/fetch_sources.py --depth 1
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -26,15 +26,15 @@ jobs:
       fail-fast: true
     steps:
       - name: "Create build dir"
-          run: |
-            $currentTime = (Get-Date).ToString('HHmmss')
-            $buildDir = "$env:BASE_BUILD_DIR_POWERSHELL\$currentTime"
-            echo "BUILD_DIR_POWERSHELL=$buildDir" >> $env:GITHUB_ENV
-            mkdir "$buildDir"
-            Write-Host "Generated Build Directory: $buildDir"
-            $bashBuildDir = $buildDir -replace '\\', '/' -replace '^C:', '/c'
-            echo  "BUILD_DIR_BASH=$bashBuildDir" >> $env:GITHUB_ENV
-            Write-Host "Converted Build Directory For Bash: $bashBuildDir"
+        run: |
+          $currentTime = (Get-Date).ToString('HHmmss')
+          $buildDir = "$env:BASE_BUILD_DIR_POWERSHELL\$currentTime"
+          echo "BUILD_DIR_POWERSHELL=$buildDir" >> $env:GITHUB_ENV
+          mkdir "$buildDir"
+          Write-Host "Generated Build Directory: $buildDir"
+          $bashBuildDir = $buildDir -replace '\\', '/' -replace '^C:', '/c'
+          echo  "BUILD_DIR_BASH=$bashBuildDir" >> $env:GITHUB_ENV
+          Write-Host "Converted Build Directory For Bash: $bashBuildDir"
 
       - name: Enabling git symlinks
         run: git config --global core.symlinks true

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -70,7 +70,7 @@ jobs:
       # really helps for iteration time.
       - name: Setup ccache
         run: choco install ccache --yes
-      # TODO: CCache via this action doesn't work. Maybe related to
+      # TODO(amd-chrissosa): CCache via this action doesn't work. Maybe related to
       # https://github.com/hendrikmuhs/ccache-action/issues/184
       #   uses: hendrikmuhs/ccache-action@53911442209d5c18de8a31615e0923161e435875 # v1.2.16
       #   with:
@@ -83,7 +83,7 @@ jobs:
           echo "Building package ${package_version}"
 
           # Build.
-          cmake -B "${{ $bashBuildDir }}" -GNinja . \
+          cmake -B "${{ env.BUILD_DIR_BASH }}" -GNinja . \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DTHEROCK_AMDGPU_FAMILIES=gfx110X-dgpu \
             -DTHEROCK_PACKAGE_VERSION="${package_version}" \
@@ -98,7 +98,7 @@ jobs:
             -DTHEROCK_ENABLE_PROFILER_SDK=OFF
 
       - name: Build Projects
-        run: cmake --build "${{ $bashBuildDir }}" build
+        run: cmake --build "${{ env.BUILD_DIR_BASH }}" build
 
       - name: "Clean up build dir"
         if: always()

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -24,9 +24,7 @@ jobs:
       fail-fast: true
     steps:
       - name: Enabling git symlinks
-        run: |
-          git config --global core.symlinks true
-          git clone https://github.com/amd-chrissosa/emptyrepo.git
+        run: git config --global core.symlinks true
 
       - name: "Checking out repository"
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
@@ -37,6 +35,7 @@ jobs:
       - name: Install ninja
         run: choco install ninja --yes
 
+        # Is this still necessary?
       - name: Install certificates
         run: python -m pip install pip-system-certs certifi python-certifi-win32
 
@@ -44,10 +43,12 @@ jobs:
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
+          # Do this within bash.
+          pip install --upgrade certifi
           # Use right credential store https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
-          git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
+          #git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
           # Use windows storage backend.
-          git config --global http.sslBackend schannel
+          #git config --global http.sslBackend schannel
           python ./build_tools/fetch_sources.py --depth 1
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -26,6 +26,7 @@ jobs:
       fail-fast: true
     steps:
       - name: "Create build dir"
+        shell: powershell
         run: |
           $currentTime = (Get-Date).ToString('HHmmss')
           $buildDir = "$env:BASE_BUILD_DIR_POWERSHELL\$currentTime"

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Fetch sources
         run: |
-          # Sets an env variable to ensure urllib3 uses the certifi CA bundle in fetch_sources.py.
+          # Sets an env variable to ensure urllib uses the certifi CA bundle in fetch_sources.py.
           export SSL_CERT_FILE=$(python3 -m certifi)
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"          

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -35,12 +35,13 @@ jobs:
       - name: Install ninja
         run: choco install ninja --yes
 
+      - name: Install Certs (ensure done outside of shell before fetching sources)
+        run: python -m pip install pip-system-certs --use-feature=truststore
+
       - name: Fetch sources
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
-          # Do this within bash.
-          python -m pip install pip-system-certs --use-feature=truststore
           # Use right credential store https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
           #git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
           # Use windows storage backend.

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -36,16 +36,12 @@ jobs:
         run: choco install ninja --yes
 
       - name: Install Certs (ensure done outside of shell before fetching sources)
-        run: python -m pip install pip-system-certs --use-feature=truststore
+        run: python -m pip install certifi
 
       - name: Fetch sources
         run: |
           git config --global user.email "nobody@amd.com"
           git config --global user.name "Nobody"
-          # Use right credential store https://learn.microsoft.com/en-us/windows/wsl/tutorials/wsl-git
-          #git config --global credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
-          # Use windows storage backend.
-          #git config --global http.sslBackend schannel
           python ./build_tools/fetch_sources.py --depth 1
       # TODO(scotttodd): Get symlinks working on CI runners instead of this
       - name: Replace symlinks with copies

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -43,7 +43,7 @@ jobs:
           # Sets an env variable to ensure urllib uses the certifi CA bundle in fetch_sources.py.
           export SSL_CERT_FILE=$(python3 -m certifi)
           git config --global user.email "nobody@amd.com"
-          git config --global user.name "Nobody"          
+          git config --global user.name "Nobody"
           python ./build_tools/fetch_sources.py --depth 1
 
       # TODO(scotttodd): Get symlinks working on CI runners instead of this

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -36,7 +36,7 @@ jobs:
         run: choco install ninja --yes
 
       - name: Install Certs (ensure done outside of shell before fetching sources)
-        run: python -m pip install -upgrade certifi
+        run: python -m pip install --upgrade certifi
 
       - name: Fetch sources
         run: |

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -36,7 +36,7 @@ jobs:
         run: choco install ninja --yes
 
       - name: Install Certs (ensure path is updated if already installed)
-        run: python -m pip install --upgrade certifi
+        run: python -m pip install certifi
 
       - name: Fetch sources
         run: |


### PR DESCRIPTION
Progress on https://github.com/nod-ai/TheRock/issues/36. These runners are more powerful than the standard GitHub-hosted runners so we can more quickly build large projects like LLVM.

* This needed credential changes that took a bit of trial and error, but the key thing wasn't git not working correctly but the nested `urllib.request` in `fetch_sources.py` not pulling in the right cert even after installing certifi. I fixed this by manually exporting the cert into the environment based on a suggestion from here: https://stackoverflow.com/questions/77442172/ssl-certificate-verify-failed-certificate-verify-failed-unable-to-get-local-is.
* The self-hosted runners have some storage space issues that we are working around with an auxiliary disk mount and some powershell commands.

Sample runs:
* https://github.com/nod-ai/TheRock/actions/runs/13409402263/job/37455854065
* https://github.com/nod-ai/TheRock/actions/runs/13424413395/job/37504333090?pr=106
* https://github.com/nod-ai/TheRock/actions/runs/13424413395/job/37506514489?pr=106