### PR TITLE
Migrate Windows workflow away from ccache-action.

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -16,12 +16,16 @@ on:
 jobs:
   build_windows_packages:
     name: Build Windows Packages
-    runs-on: windows-2022  # TODO(#36): move to cluster of CPU builders like `azure-windows-scale-nod-ai`
+    runs-on: windows-2022 # TODO(#36): move to cluster of CPU builders like `azure-windows-scale-nod-ai`
     defaults:
       run:
         shell: bash
     strategy:
       fail-fast: true
+    env:
+      CACHE_DIR: ${{ github.workspace }}/.cache
+      CCACHE_DIR: "${{ github.workspace }}/.cache/ccache"
+      CCACHE_MAXSIZE: "700M"
     steps:
       - name: Enabling git symlinks
         run: git config --global core.symlinks true
@@ -31,8 +35,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install ninja
-        run: choco install ninja --yes
+      - name: Install requirements
+        run: |
+          choco install ccache --yes
+          choco install ninja --yes
 
       - name: Fetch sources
         run: |
@@ -48,10 +54,13 @@ jobs:
 
       # TODO: We shouldn't be using a cache on actual release branches, but it
       # really helps for iteration time.
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@53911442209d5c18de8a31615e0923161e435875 # v1.2.16
+      - name: Enable cache
+        uses: actions/cache/restore@v4
         with:
-          key: windows-build-packages-v1
+          path: ${{ env.CACHE_DIR }}
+          key: windows-build-packages-v2-${{ github.sha }}
+          restore-keys: |
+            windows-build-packages-v2-
 
       - name: Configure Projects
         run: |
@@ -80,4 +89,16 @@ jobs:
       - name: Report
         if: ${{ !cancelled() }}
         run: |
+          echo "Build dir:"
+          echo "------------"
           ls -lh build
+          echo "CCache Stats:"
+          echo "-------------"
+          ccache -s
+
+      - name: Save cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: ${{ env.CACHE_DIR }}
+          key: windows-build-packages-v2-${{ github.sha }}

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -40,6 +40,26 @@ jobs:
           choco install ccache --yes
           choco install ninja --yes
 
+      - name: Report Runner Health
+        run: |
+          echo "CCACHE_DIR=${CCACHE_DIR}"
+          df -h
+          ccache -z
+          mkdir -p $CCACHE_DIR
+          cmake --version
+          echo "python: $(which python), python3: $(which python3)"
+          echo "Git version: $(git --version)"
+
+      # TODO: We shouldn't be using a cache on actual release branches, but it
+      # really helps for iteration time.
+      - name: Enable cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CACHE_DIR }}
+          key: windows-build-packages-v2-${{ github.sha }}
+          restore-keys: |
+            windows-build-packages-v2-
+
       - name: Fetch sources
         run: |
           git config --global user.email "nobody@amd.com"
@@ -51,16 +71,6 @@ jobs:
 
       - name: Configure MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-
-      # TODO: We shouldn't be using a cache on actual release branches, but it
-      # really helps for iteration time.
-      - name: Enable cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.CACHE_DIR }}
-          key: windows-build-packages-v2-${{ github.sha }}
-          restore-keys: |
-            windows-build-packages-v2-
 
       - name: Configure Projects
         run: |


### PR DESCRIPTION
The [ccache-action](https://github.com/hendrikmuhs/ccache-action) sometimes fails to set up on self-hosted runners. This explicit usage may be more robust.

This will supersede https://github.com/nod-ai/TheRock/pull/106 (see the discussion at https://github.com/nod-ai/TheRock/pull/106#discussion_r1962015427).

Test | Logs
-- | --
Cold cache | https://github.com/nod-ai/TheRock/actions/runs/13418973609/attempts/1?pr=107
Warm cache | https://github.com/nod-ai/TheRock/actions/runs/13418973609/attempts/2?pr=107