### PR TITLE
Enable and document ccache + MSVC workaround for LLVM.

### DIFF
--- a/cmake/therock_subproject.cmake
+++ b/cmake/therock_subproject.cmake
@@ -857,6 +857,7 @@ function(_therock_cmake_subproject_setup_toolchain compiler_toolchain toolchain_
   string(APPEND _toolchain_contents "set(CMAKE_LINKER \"@CMAKE_LINKER@\")\n")
   string(APPEND _toolchain_contents "set(CMAKE_C_COMPILER_LAUNCHER \"@CMAKE_C_COMPILER_LAUNCHER@\")\n")
   string(APPEND _toolchain_contents "set(CMAKE_CXX_COMPILER_LAUNCHER \"@CMAKE_CXX_COMPILER_LAUNCHER@\")\n")
+  string(APPEND _toolchain_contents "set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT \"@CMAKE_MSVC_DEBUG_INFORMATION_FORMAT@\")\n")
   string(APPEND _toolchain_contents "set(CMAKE_C_FLAGS_INIT @CMAKE_C_FLAGS@)\n")
   string(APPEND _toolchain_contents "set(CMAKE_CXX_FLAGS_INIT @CMAKE_CXX_FLAGS@)\n")
   string(APPEND _toolchain_contents "set(CMAKE_EXE_LINKER_FLAGS_INIT @CMAKE_EXE_LINKER_FLAGS@)\n")

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -120,7 +120,18 @@ cmake -B build -GNinja . \
 # If iterating and wishing to cache, add these:
 #  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
 #  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+#  -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded \
 ```
+
+> [!TIP]
+> ccache [does not support](https://github.com/ccache/ccache/issues/1040)
+> MSVC's `/Zi` flag which may be set by default when a project (e.g. LLVM) opts
+> in to
+> [policy CMP0141](https://cmake.org/cmake/help/latest/policy/CMP0141.html).
+> Setting
+> [`-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded`](https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_DEBUG_INFORMATION_FORMAT.html)
+> instructs CMake to compile with `/Z7` or equivalent, which is supported by
+> ccache.
 
 Ensure that MSVC is used by looking for lines like these in the logs:
 


### PR DESCRIPTION
Progress on https://github.com/nod-ai/TheRock/issues/36. This fixes ccache when compiling with `-DCMAKE_BUILD_TYPE=RelWithDebInfo` and MSVC on Windows.

Before:
```
λ ccache --show-stats
Cacheable calls:      0 / 4309 ( 0.00%)
  Hits:               0
    Direct:           0
    Preprocessed:     0
  Misses:             0
Uncacheable calls: 4309 / 4309 (100.0%)
Local storage:
  Cache size (GB):  0.0 / 50.0 ( 0.00%)
```

After:
```
λ ccache --show-stats
Cacheable calls:   4099 / 4309 (95.13%)
  Hits:            4054 / 4099 (98.90%)
    Direct:        3482 / 4054 (85.89%)
    Preprocessed:   572 / 4054 (14.11%)
  Misses:            45 / 4099 ( 1.10%)
Uncacheable calls:  210 / 4309 ( 4.87%)
Local storage:
  Cache size (GB):  4.2 / 50.0 ( 8.34%)
  Hits:            4054 / 4099 (98.90%)
  Misses:            45 / 4099 ( 1.10%)
```

We had a different workaround in IREE: https://github.com/iree-org/iree/pull/11841. I tried a solution like that one in this project but the meta-project nature of TheRock discourages setting implicit top level options. Instead, I followed how other options like `CMAKE_CXX_COMPILER_LAUNCHER` are forwarded to subprojects explicitly.


### Debugging notes

I followed https://ccache.dev/manual/4.10.2.html#_cache_debugging:

```bash
ccache --set-config debug=true
ccache --set-config debug_dir=D:\cache\ccache_debug
ccache --show-config
# confirm that the options are set
```

Then I looked in files like `D:\cache\ccache_debug\projects\TheRock\build\compiler\amd-llvm\build\lib\Support\CMakeFiles\LLVMSupport.dir\Allocator.cpp.obj.20250219_112722_308872.ccache-log`

and found logs like these:
```
[2025-02-19T11:27:22.309172 28480] Command line: ccache C:\\PROGRA~2\\MICROS~2\\2022\\BUILDT~1\\VC\\Tools\\MSVC\\1442~1.344\\bin\\Hostx64\\x64\\cl.exe /nologo /TP -DGTEST_HAS_RTTI=0 -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_HAS_EXCEPTIONS=0 -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -ID:\\projects\\TheRock\\build\\compiler\\amd-llvm\\build\\lib\\Support -ID:\\projects\\TheRock\\compiler\\amd-llvm\\llvm\\lib\\Support -ID:\\projects\\TheRock\\build\\compiler\\amd-llvm\\build\\include -ID:\\projects\\TheRock\\compiler\\amd-llvm\\llvm\\include /DWIN32;/D_WINDOWS;/EHsc /DWIN32 /D_WINDOWS /Zc:inline /Zc:preprocessor /Zc:__cplusplus /Oi /bigobj /permissive- /W4 -wd4141 -wd4146 -wd4244 -wd4267 -wd4291 -wd4351 -wd4456 -wd4457 -wd4458 -wd4459 -wd4503 -wd4624 -wd4722 -wd4100 -wd4127 -wd4512 -wd4505 -wd4610 -wd4510 -wd4702 -wd4245 -wd4706 -wd4310 -wd4701 -wd4703 -wd4389 -wd4611 -wd4805 -wd4204 -wd4577 -wd4091 -wd4592 -wd4319 -wd4709 -wd5105 -wd4324 -w14062 -we4238 /Gw /O2 /Ob1 /DNDEBUG -std:c++17 -MD -Zi /EHs-c- /GR- /showIncludes /Folib\\Support\\CMakeFiles\\LLVMSupport.dir\\Allocator.cpp.obj /Fdlib\\Support\\CMakeFiles\\LLVMSupport.dir\\LLVMSupport.pdb /FS -c D:\\projects\\TheRock\\compiler\\amd-llvm\\llvm\\lib\\Support\\Allocator.cpp
[2025-02-19T11:27:22.312459 28480] Hostname: DESKTOP-HTCE3IS
[2025-02-19T11:27:22.312465 28480] Working directory: D:\projects\TheRock\build\compiler\amd-llvm\build
[2025-02-19T11:27:22.312475 28480] Compiler: C:\PROGRA~2\MICROS~2\2022\BUILDT~1\VC\Tools\MSVC\1442~1.344\bin\Hostx64\x64\cl.exe
[2025-02-19T11:27:22.312476 28480] Compiler type: msvc
[2025-02-19T11:27:22.312846 28480] Detected input file: D:\projects\TheRock\compiler\amd-llvm\llvm\lib\Support\Allocator.cpp
[2025-02-19T11:27:22.312852 28480] Compiler option -Zi is unsupported
[2025-02-19T11:27:22.312857 28480] Failed; falling back to running the real compiler
```

From there it was whack-a-mole trying to find where the `-Zi` flag came from, checking source code and eventually finding https://github.com/llvm/llvm-project/blob/c0c42c8b3213520700f15587ab8aa4477a286ff9/cmake/Modules/CMakePolicy.cmake#L9-L20. Reading the docs informed me that my prior workaround of manipulating `CMAKE_C_FLAGS_RELWITHDEBINFO` is outdated and actually won't work when the new policy is enabled.

With the right fix, I deleted my build directory, re-ran a full build, and checked the ccache stats and log files to ensure that ccache was operating as expected again.