### PR TITLE
Upload artifacts and logs to S3 bucket

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -128,14 +128,14 @@ jobs:
       # TODO: Move to script
       - name: Upload Artifacts
         run: |
-          aws s3 sync build/artifacts s3://therock-artifacts/${{github.run_id}}/ \
-            --exclude "*" --include "*.tar.xz*" --include "index.html"
+          aws s3 cp build/artifacts/ s3://therock-artifacts/${{github.run_id}}/ \
+            --recursive --exclude "*" --include "*.tar.xz*" --include "index.html"
 
       # TODO: Move to script
       - name: Upload Logs
         run: |
-          aws s3 sync build/logs s3://therock-artifacts/${{github.run_id}}/logs/ \
-            --exclude "*" --include "*.log" --include "index.html"
+          aws s3 cp build/logs/ s3://therock-artifacts/${{github.run_id}}/logs/ \
+            --recursive --exclude "*" --include "*.log" --include "index.html"
 
       - name: Add Links to Job Summary
         run: |

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -129,13 +129,17 @@ jobs:
       - name: Upload Artifacts
         run: |
           aws s3 cp build/artifacts/ s3://therock-artifacts/${{github.run_id}}/ \
-            --recursive --exclude "*" --include "*.tar.xz*" --include "index.html"
+            --recursive --no-follow-symlinks \
+            --exclude "*" \
+            --include "*.tar.xz*" --include "index.html"
 
       # TODO: Move to script
       - name: Upload Logs
         run: |
           aws s3 cp build/logs/ s3://therock-artifacts/${{github.run_id}}/logs/ \
-            --recursive --exclude "*" --include "*.log" --include "index.html"
+            --recursive \
+            --exclude "*" \
+            --include "*.log" --include "index.html"
 
       - name: Add Links to Job Summary
         run: |

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -108,3 +108,32 @@ jobs:
         with:
           path: ${{ env.CACHE_DIR }}
           key: linux-build-packages-manylinux-v2-${{ github.sha }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-artifacts
+
+      # TODO: Move to script
+      - name: Create Index Files
+        run: |
+          curl --silent --fail --show-error --location \
+            https://raw.githubusercontent.com/joshbrunty/Indexer/6d8cbfd15d3853b482e6a49f2d875ded9188b721/indexer.py \
+            --output build/indexer.py
+          python build/indexer.py -f '*.tar.xz*' build/artifacts/
+          python build/indexer.py -f '*.log' build/logs/
+          sed -i 's,a href="..",a href="../index.html",g' build/logs/index.html
+
+      # TODO: Move to script
+      - name: Upload Artifacts & Logs
+        run: |
+          aws s3 sync build/artifacts s3://therock-artifacts/${{github.run_id}}/ \
+            --exclude "*" --include "*.tar.xz*" --include "index.html"
+          aws s3 sync build/logs s3://therock-artifacts/${{github.run_id}}/logs/ \
+            --exclude "*" --include "*.log" --include "index.html"
+
+      - name: Add Links to Job Summary
+        run: |
+          echo '* [Artifacts](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}/index.html)' >> $GITHUB_STEP_SUMMARY
+          echo '* [Build logs](https://therock-artifacts.s3.us-east-2.amazonaws.com/${{github.run_id}}/logs/index.html)' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -126,10 +126,14 @@ jobs:
           sed -i 's,a href="..",a href="../index.html",g' build/logs/index.html
 
       # TODO: Move to script
-      - name: Upload Artifacts & Logs
+      - name: Upload Artifacts
         run: |
           aws s3 sync build/artifacts s3://therock-artifacts/${{github.run_id}}/ \
             --exclude "*" --include "*.tar.xz*" --include "index.html"
+
+      # TODO: Move to script
+      - name: Upload Logs
+        run: |
           aws s3 sync build/logs s3://therock-artifacts/${{github.run_id}}/logs/ \
             --exclude "*" --include "*.log" --include "index.html"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
     inputs:
 
+permissions:
+  contents: read
+
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
@@ -18,6 +21,8 @@ concurrency:
 
 jobs:
   build_linux_packages:
+    permissions:
+      id-token: write
     name: Build Linux Packages
     uses: ./.github/workflows/build_linux_packages.yml
 


### PR DESCRIPTION
* Uses the `configure-aws-credentials` action to retrieve short-lived
  credentials using GitHub's OIDC provider
* Creates index of files using the MIT-licensed indexer.py script
* Uploads artifacts and logs to the S3 bucket
* Adds links pointing to the bucket to the job summary

Creating index files and uploading files is to be moved to scripts in a
follow up.