### PR TITLE
Fix a couple of items that were causing false dependence on system libs.

### DIFF
--- a/patches/amd-mainline/ROCR-Runtime/0001-Search-for-libnuma-with-find_package-before-find_lib.patch
+++ b/patches/amd-mainline/ROCR-Runtime/0001-Search-for-libnuma-with-find_package-before-find_lib.patch
@@ -1,0 +1,51 @@
+From 1b4325c9e4646942467c91005ef3297a3eb10f27 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Mon, 24 Feb 2025 23:04:55 -0800
+Subject: [PATCH] Search for libnuma with find_package before find_library.
+
+This avoids a false dependence on a system library when not desired.
+---
+ libhsakmt/CMakeLists.txt | 17 ++++++++++++-----
+ 1 file changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/libhsakmt/CMakeLists.txt b/libhsakmt/CMakeLists.txt
+index 0539f468..e5e237c4 100644
+--- a/libhsakmt/CMakeLists.txt
++++ b/libhsakmt/CMakeLists.txt
+@@ -164,13 +164,20 @@ get_os_info()
+ find_package(PkgConfig)
+ # Check for libraries required for building
+ find_library(LIBC NAMES c REQUIRED)
+-find_library(NUMA NAMES numa REQUIRED)
+-message(STATUS "LIBC:" ${LIBC})
+-message(STATUS "NUMA:" ${NUMA})
++find_package(NUMA)
++if(NUMA_FOUND)
++  set(NUMA "${NUMA_LIBRARIES}")
++else()
++  find_library(NUMA NAMES numa REQUIRED)
++endif()
++message(STATUS "LIBC: " ${LIBC})
++message(STATUS "NUMA: " ${NUMA})
+ 
+ ## If environment variable DRM_DIR is set, the script
+ ## will pick up the corresponding libraries from that path.
+-list (PREPEND CMAKE_PREFIX_PATH "${DRM_DIR}")
++if(DRM_DIR)
++  list (PREPEND CMAKE_PREFIX_PATH "${DRM_DIR}")
++endif()
+ 
+ # The module name passed to pkg_check_modules() is determined by the
+ # name of file *.pc
+@@ -180,7 +187,7 @@ include_directories(${DRM_AMDGPU_INCLUDE_DIRS})
+ include_directories(${DRM_INCLUDE_DIRS})
+ 
+ target_link_libraries ( ${HSAKMT_TARGET}
+-  PRIVATE ${DRM_LDFLAGS} ${DRM_AMDGPU_LDFLAGS} pthread rt c numa ${CMAKE_DL_LIBS}
++  PRIVATE ${DRM_LDFLAGS} ${DRM_AMDGPU_LDFLAGS} pthread rt ${LIBC} ${NUMA} ${CMAKE_DL_LIBS}
+ )
+ 
+ target_compile_options(${HSAKMT_TARGET} PRIVATE ${DRM_CFLAGS} ${HSAKMT_C_FLAGS})
+-- 
+2.43.0
+

--- a/patches/amd-mainline/rocprofiler-sdk/0001-Extend-the-hack-to-propagate-HIP-usage-requirements-.patch
+++ b/patches/amd-mainline/rocprofiler-sdk/0001-Extend-the-hack-to-propagate-HIP-usage-requirements-.patch
@@ -1,7 +1,7 @@
 From 18b6d7a535fd3b9bcd13df9c20a8532efded101f Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Wed, 12 Feb 2025 18:38:02 -0800
-Subject: [PATCH 1/2] Extend the hack to propagate HIP usage requirements a bit
+Subject: [PATCH 1/3] Extend the hack to propagate HIP usage requirements a bit
  further.
 
 * Also fetches usage requirements from hip::amdhip64 -> rocprofiler-sdk-hip-nolink

--- a/patches/amd-mainline/rocprofiler-sdk/0002-Align-configuration-of-libdrm-with-how-ROCR-does-it.patch
+++ b/patches/amd-mainline/rocprofiler-sdk/0002-Align-configuration-of-libdrm-with-how-ROCR-does-it.patch
@@ -1,7 +1,7 @@
 From 68c2b27e58c55bca97d627c5b6e6c3a144da1821 Mon Sep 17 00:00:00 2001
 From: Stella Laurenzo <stellaraccident@gmail.com>
 Date: Mon, 24 Feb 2025 20:48:50 -0800
-Subject: [PATCH 2/2] Align configuration of libdrm with how ROCR does it.
+Subject: [PATCH 2/3] Align configuration of libdrm with how ROCR does it.
 
 * We should always be using some form of package based lookup for this, not loose-leaf path scanning.
 * I couldn't find any dependency on the xfree86 headers so deleted that lookup/include.

--- a/patches/amd-mainline/rocprofiler-sdk/0003-Depend-on-libdw-from-libraries-that-consume-its-head.patch
+++ b/patches/amd-mainline/rocprofiler-sdk/0003-Depend-on-libdw-from-libraries-that-consume-its-head.patch
@@ -1,0 +1,34 @@
+From 2efd19e6e3d43bc97383dcff45c9205bbb1ee9c7 Mon Sep 17 00:00:00 2001
+From: Stella Laurenzo <stellaraccident@gmail.com>
+Date: Mon, 24 Feb 2025 23:05:42 -0800
+Subject: [PATCH 3/3] Depend on libdw from libraries that consume its header.
+
+---
+ source/lib/common/CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/source/lib/common/CMakeLists.txt b/source/lib/common/CMakeLists.txt
+index bb43bc2..4870156 100644
+--- a/source/lib/common/CMakeLists.txt
++++ b/source/lib/common/CMakeLists.txt
+@@ -38,6 +38,7 @@ target_link_libraries(
+     rocprofiler-sdk-common-library
+     PUBLIC $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-headers>
+            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-build-flags>
++           $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-dw>
+            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-threading>
+            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-memcheck>
+            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-cxx-filesystem>
+@@ -48,7 +49,8 @@ target_link_libraries(
+            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-ptl>
+            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-atomic>
+            $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-hsakmt-nolink>
+-           $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-elfio>)
++           $<BUILD_INTERFACE:rocprofiler-sdk::rocprofiler-sdk-elfio>
++           )
+ 
+ set_target_properties(rocprofiler-sdk-common-library PROPERTIES OUTPUT_NAME
+                                                                 rocprofiler-sdk-common)
+-- 
+2.43.0
+

--- a/third-party/sysdeps/linux/elfutils/CMakeLists.txt
+++ b/third-party/sysdeps/linux/elfutils/CMakeLists.txt
@@ -75,6 +75,14 @@ add_custom_target(
   COMMAND
     "${CMAKE_CURRENT_SOURCE_DIR}/patch_source.sh" "${CMAKE_CURRENT_BINARY_DIR}/s"
   COMMAND
+    # CMake copy directory does not preserve timestamps. If the stamp-po is
+    # out of date, the build will try to regenerate docs, which requires a bunch
+    # of extra tools and fails mysteriously if not present with something like:
+    #   mv: cannot stat 't-de.gmo': No such file or directory
+    # Ensuring it has the most current timestamp post copy/patch disables doc
+    # regneration.
+    "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/s/po/stamp-po"
+  COMMAND
     "${CMAKE_COMMAND}" -E env
       "PKG_CONFIG_PATH=$ENV{PKG_CONFIG_PATH}"
       # Escaping: Double $ to satisfy CMake, then double $ to satisfy configure,

--- a/third-party/sysdeps/linux/elfutils/CMakeLists.txt
+++ b/third-party/sysdeps/linux/elfutils/CMakeLists.txt
@@ -55,6 +55,15 @@ if(NOT PATCHELF)
   message(FATAL_ERROR "Missing PATCHELF from super-project")
 endif()
 
+# HACK: elfutils consults pkg-config for cflags for the compression libraries
+# but then does not seem to use them everywhere needed. So we just hard-code
+# paths.
+set(EXTRA_CPPFLAGS)
+string(APPEND EXTRA_CPPFLAGS " -I${THEROCK_BINARY_DIR}/third-party/sysdeps/linux/bzip2/build/stage/lib/rocm_sysdeps/include")
+string(APPEND EXTRA_CPPFLAGS " -I${THEROCK_BINARY_DIR}/third-party/sysdeps/linux/zlib/build/stage/lib/rocm_sysdeps/include")
+string(APPEND EXTRA_CPPFLAGS " -I${THEROCK_BINARY_DIR}/third-party/sysdeps/linux/zstd/build/stage/lib/rocm_sysdeps/include")
+message(STATUS "EXTRA_CPPFLAGS=${EXTRA_CPPFLAGS}")
+
 add_custom_target(
   build ALL
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
@@ -71,6 +80,7 @@ add_custom_target(
       # Escaping: Double $ to satisfy CMake, then double $ to satisfy configure,
       # then escaped single quotes to make it to the linker command line.
       "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath=\\'\\$$\\$$ORIGIN\\'"
+      "CPPFLAGS=${EXTRA_CPPFLAGS}"
       --
     "${CMAKE_CURRENT_BINARY_DIR}/s/configure"
       --prefix "${CMAKE_INSTALL_PREFIX}"


### PR DESCRIPTION
* elfutils build does not add the compressor include directories to everywhere that need it.
* ROCR-Runtime uses find_library to find NUMA.
* rocprofiler-sdk uses libdw headers in libraries that do not depend on it.