### PR TITLE
Set default permissions and pin actions

### DIFF
--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -21,6 +21,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit

--- a/.github/workflows/portable_linux_package_matrix.yml
+++ b/.github/workflows/portable_linux_package_matrix.yml
@@ -53,14 +53,14 @@ jobs:
       DIST_ARCHIVE: "${{ github.workspace }}/output/therock-dist-${{ matrix.target_bundle.amdgpu_family }}${{ github.events.input.package_suffix }}.tar.gz"
     steps:
       - name: "Checking out repository"
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
-      - uses: actions/setup-python@v5
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
       # TODO: We shouldn't be using a cache on actual release branches, but it
       # really helps for iteration time.
       - name: Enable cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         with:
           path: ${{ env.OUTPUT_DIR }}/caches
           key: portable-linux-package-matrix-v1-${{ matrix.target_bundle.amdgpu_family }}-${{ github.sha }}
@@ -96,7 +96,7 @@ jobs:
           tar cfz "${{ env.DIST_ARCHIVE }}" .
 
       - name: Upload Release Asset
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         if: github.event.inputs.release_tag != ''
         with:
           artifacts: "${{ env.DIST_ARCHIVE }}"
@@ -115,7 +115,7 @@ jobs:
           du -h -d 1 ${{ env.OUTPUT_DIR }}/build/dist/rocm
 
       - name: Save cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         if: always()
         with:
           path: ${{ env.OUTPUT_DIR }}/caches


### PR DESCRIPTION
* Sets default permissions explicitly
* Pins (and updates) actions as suggested by the OpenSSF Scorecard
  project, see
  https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies.

  Pinned actions can be upgraded by Dependabot which will be added in a
  follow up.