### PR TITLE
Pin remaining actions

### DIFF
--- a/.github/workflows/build_linux_packages.yml
+++ b/.github/workflows/build_linux_packages.yml
@@ -45,7 +45,7 @@ jobs:
       # TODO: We shouldn't be using a cache on actual release branches, but it
       # really helps for iteration time.
       - name: Enable cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         with:
           path: ${{ env.CACHE_DIR }}
           key: linux-build-packages-manylinux-v2-${{ github.sha }}
@@ -103,7 +103,7 @@ jobs:
           ccache -s
 
       - name: Save cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         if: always()
         with:
           path: ${{ env.CACHE_DIR }}

--- a/.github/workflows/build_python_packages.yml
+++ b/.github/workflows/build_python_packages.yml
@@ -50,7 +50,7 @@ jobs:
       # TODO: We shouldn't be using a cache on actual release branches, but it
       # really helps for iteration time.
       - name: Enable cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         with:
           path: ${{ env.CACHE_DIR }}
           key: build-python-manylinux-v2-${{ github.sha }}
@@ -88,7 +88,7 @@ jobs:
           ls -lh . wheelhouse
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: ${{ !cancelled() }}
         with:
           name: TheRock-runtime-linux-x86_64-python
@@ -97,7 +97,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Save cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         if: always()
         with:
           path: ${{ env.CACHE_DIR }}

--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -67,7 +67,7 @@ jobs:
       # TODO: We shouldn't be using a cache on actual release branches, but it
       # really helps for iteration time.
       - name: Enable cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         with:
           path: ${{ env.CACHE_DIR }}
           key: windows-build-packages-v2-${{ github.sha }}
@@ -135,7 +135,7 @@ jobs:
           ccache -s
 
       - name: Save cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         if: always()
         with:
           path: ${{ env.CACHE_DIR }}

--- a/.github/workflows/publish_build_manylinux_x86_64.yml
+++ b/.github/workflows/publish_build_manylinux_x86_64.yml
@@ -20,23 +20,23 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.9
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: dockerfiles
           file: dockerfiles/build_manylinux_x86_64.Dockerfile


### PR DESCRIPTION
Pins the remaining actions to a known tagged release with its hash as suggested by OpenSSF Scorecard, see
https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies.