### PR TITLE
Uplift how artifacts are handled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,8 @@ endif()
 # External project setup
 ################################################################################
 
+add_subdirectory(build_tools)
+
 # Add subdirectories in dependency DAG order (which happens to be semi-alpha:
 # don't be fooled).
 add_subdirectory(third-party)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ set(ROCM_SYMLINK_LIBS OFF)
 message(STATUS "ROCM_GIT_DIR is set to: ${ROCM_GIT_DIR}")
 
 set(THEROCK_ARTIFACT_ARCHIVE_SUFFIX "" CACHE STRING "Suffix to add to artifact archive file stem names")
-set(THEROCK_ARTIFACT_ARCHIVE_TYPES "tar.xz" CACHE STRING "List of artifact archive types to generate")
 
 cmake_dependent_option(
   THEROCK_BUNDLE_SYSDEPS "Builds bundled system deps for portable builds into lib/rocm_sysdeps"

--- a/build_tools/CMakeLists.txt
+++ b/build_tools/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_test(
+    NAME build_tools_fileset_tool_test
+    COMMAND "${Python3_EXECUTABLE}" 
+        "${CMAKE_CURRENT_SOURCE_DIR}/tests/fileset_tool_test.py"
+)

--- a/build_tools/CMakeLists.txt
+++ b/build_tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_test(
     NAME build_tools_fileset_tool_test
-    COMMAND "${Python3_EXECUTABLE}" 
+    COMMAND "${Python3_EXECUTABLE}"
         "${CMAKE_CURRENT_SOURCE_DIR}/tests/fileset_tool_test.py"
 )

--- a/build_tools/tests/fileset_tool_test.py
+++ b/build_tools/tests/fileset_tool_test.py
@@ -1,0 +1,161 @@
+import hashlib
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+import tempfile
+import unittest
+
+FILESET_TOOL = Path(__file__).parent.parent / "fileset_tool.py"
+
+ARTIFACT_DESCRIPTOR_1 = r"""
+[components.doc."example/stage"]
+"""
+
+
+def exec(args: list[str | Path], cwd: Path = FILESET_TOOL.parent):
+    args = [str(arg) for arg in args]
+    print(f"++ Exec [{cwd}]$ {shlex.join(args)}")
+    subprocess.check_call(args, cwd=str(cwd), stdin=subprocess.DEVNULL)
+
+
+def write_text(p: Path, text: str):
+    p.parent.mkdir(exist_ok=True, parents=True)
+    p.write_text(text)
+
+
+class FilesetToolTest(unittest.TestCase):
+    def setUp(self):
+        override_temp = os.getenv("TEST_TMPDIR")
+        if override_temp is not None:
+            self.temp_context = None
+            self.temp_dir = Path(override_temp)
+            self.temp_dir.mkdir(parents=True, exist_ok=True)
+        else:
+            self.temp_context = tempfile.TemporaryDirectory()
+            self.temp_dir = Path(self.temp_context.name)
+
+    def tearDown(self):
+        if self.temp_context:
+            self.temp_context.cleanup()
+
+    # Validates that the happy path flow of creating an artifact, archiving it,
+    # expanding and flattening works. This does not exhaustively verify
+    # all descriptor options.
+    def testSimpleArtifact(self):
+        input_dir = self.temp_dir / "input"
+        artifact_dir = self.temp_dir / "artifact_dir"
+        artifact_archive = self.temp_dir / "artifact.tar.xz"
+        descriptor_file = self.temp_dir / "artifact.toml"
+        hash_file = self.temp_dir / "artifact.tar.xz.sha256sum"
+        flat1_dir = self.temp_dir / "flat1"
+        flat2_dir = self.temp_dir / "flat2"
+        write_text(descriptor_file, ARTIFACT_DESCRIPTOR_1)
+
+        # One sample file and a symlink.
+        write_text(
+            input_dir / "example" / "stage" / "share" / "doc" / "README.txt",
+            "Hello World!",
+        )
+        Path(input_dir / "example" / "stage" / "share" / "doc" / "README").symlink_to(
+            "README.txt"
+        )
+        exec(
+            [
+                sys.executable,
+                FILESET_TOOL,
+                "artifact",
+                "--descriptor",
+                descriptor_file,
+                "--output-dir",
+                artifact_dir,
+                "--root-dir",
+                input_dir,
+                "--component",
+                "doc",
+            ]
+        )
+
+        # Validate artifact dir.
+        manifest_lines = (
+            (artifact_dir / "artifact_manifest.txt").read_text().strip().splitlines()
+        )
+        self.assertEqual(manifest_lines, ["example/stage"])
+        self.assertEqual(
+            (
+                artifact_dir / "example" / "stage" / "share" / "doc" / "README.txt"
+            ).read_text(),
+            "Hello World!",
+        )
+        self.assertEqual(
+            os.readlink(
+                artifact_dir / "example" / "stage" / "share" / "doc" / "README"
+            ),
+            "README.txt",
+        )
+
+        # Archive it.
+        exec(
+            [
+                sys.executable,
+                FILESET_TOOL,
+                "artifact-archive",
+                artifact_dir,
+                "-o",
+                artifact_archive,
+                "--hash-file",
+                hash_file,
+            ]
+        )
+
+        # Verify digest.
+        with open(artifact_archive, "rb") as f:
+            expected_digest = hashlib.file_digest(f, "sha256").hexdigest()
+        actual_digest = hash_file.read_text().strip()
+        self.assertEqual(expected_digest, actual_digest)
+
+        # Flatten the raw directory and verify.
+        exec(
+            [
+                sys.executable,
+                FILESET_TOOL,
+                "artifact-flatten",
+                artifact_dir,
+                "-o",
+                flat1_dir,
+            ]
+        )
+        self.assertEqual(
+            (flat1_dir / "share" / "doc" / "README.txt").read_text(),
+            "Hello World!",
+        )
+        self.assertEqual(
+            os.readlink(flat1_dir / "share" / "doc" / "README"),
+            "README.txt",
+        )
+
+        # Flatten the archive file and verify.
+        exec(
+            [
+                sys.executable,
+                FILESET_TOOL,
+                "artifact-flatten",
+                artifact_archive,
+                "-o",
+                flat1_dir,
+            ]
+        )
+        self.assertEqual(
+            (flat1_dir / "share" / "doc" / "README.txt").read_text(),
+            "Hello World!",
+        )
+        self.assertEqual(
+            os.readlink(flat1_dir / "share" / "doc" / "README"),
+            "README.txt",
+        )
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/tests/fileset_tool_test.py
+++ b/build_tools/tests/fileset_tool_test.py
@@ -160,9 +160,7 @@ class FilesetToolTest(unittest.TestCase):
             "README.txt",
         )
         if not is_windows():
-            self.assertTrue(
-                is_executable(flat1_dir / "share" / "doc" / "executable")
-            )
+            self.assertTrue(is_executable(flat1_dir / "share" / "doc" / "executable"))
 
         # Flatten the archive file and verify.
         exec(
@@ -184,9 +182,7 @@ class FilesetToolTest(unittest.TestCase):
             "README.txt",
         )
         if not is_windows():
-            self.assertTrue(
-                is_executable(flat2_dir / "share" / "doc" / "executable")
-            )
+            self.assertTrue(is_executable(flat2_dir / "share" / "doc" / "executable"))
 
 
 if __name__ == "__main__":

--- a/cmake/therock_artifacts.cmake
+++ b/cmake/therock_artifacts.cmake
@@ -40,7 +40,7 @@ function(therock_provide_artifact slice_name)
 
   # Determine top-level name.
   if(ARG_TARGET_NEUTRAL)
-    set(_bundle_suffix "")
+    set(_bundle_suffix "_generic")
   else()
     set(_bundle_suffix "_${THEROCK_AMDGPU_DIST_BUNDLE_NAME}")
   endif()

--- a/cmake/therock_artifacts.cmake
+++ b/cmake/therock_artifacts.cmake
@@ -64,7 +64,6 @@ function(therock_provide_artifact slice_name)
         --output-dir "${_component_dir}"
         --root-dir "${THEROCK_BINARY_DIR}" --descriptor "${ARG_DESCRIPTOR}"
         --component "${_component}"
-        --manifest "${_manifest_file}"
     )
   endforeach()
 
@@ -87,27 +86,25 @@ function(therock_provide_artifact slice_name)
   ### Generate artifact archive commands.
   set(_archive_files)
   foreach(_component ${ARG_COMPONENTS})
-    foreach(_archive_type ${THEROCK_ARTIFACT_ARCHIVE_TYPES})
-      set(_component_dir "${THEROCK_BINARY_DIR}/artifacts/${slice_name}_${_component}${_bundle_suffix}")
-      set(_manifest_file "${_component_dir}/artifact_manifest.txt")
-      set(_archive_file "${THEROCK_BINARY_DIR}/artifacts/${slice_name}_${_component}${_bundle_suffix}${THEROCK_ARTIFACT_ARCHIVE_SUFFIX}.${_archive_type}")
-      list(APPEND _archive_files "${_archive_file}")
-      set(_archive_sha_file "${_archive_file}.sha256sum")
-      add_custom_command(
-        OUTPUT
-          "${_archive_file}"
-          "${_archive_sha_file}"
-        COMMENT "Creating archive ${_archive_file}"
-        COMMAND
-          "${Python3_EXECUTABLE}" "${_fileset_tool}"
-          artifact-archive "${_component_dir}"
-            -o "${_archive_file}" --type "${_archive_type}"
-            --hash-file "${_archive_sha_file}" --hash-algorithm sha256
-        DEPENDS
-          "${_manifest_file}"
-          "${_fileset_tool}"
-      )
-    endforeach()
+    set(_component_dir "${THEROCK_BINARY_DIR}/artifacts/${slice_name}_${_component}${_bundle_suffix}")
+    set(_manifest_file "${_component_dir}/artifact_manifest.txt")
+    set(_archive_file "${THEROCK_BINARY_DIR}/artifacts/${slice_name}_${_component}${_bundle_suffix}${THEROCK_ARTIFACT_ARCHIVE_SUFFIX}.tar.xz")
+    list(APPEND _archive_files "${_archive_file}")
+    set(_archive_sha_file "${_archive_file}.sha256sum")
+    add_custom_command(
+      OUTPUT
+        "${_archive_file}"
+        "${_archive_sha_file}"
+      COMMENT "Creating archive ${_archive_file}"
+      COMMAND
+        "${Python3_EXECUTABLE}" "${_fileset_tool}"
+        artifact-archive "${_component_dir}"
+          -o "${_archive_file}"
+          --hash-file "${_archive_sha_file}" --hash-algorithm sha256
+      DEPENDS
+        "${_manifest_file}"
+        "${_fileset_tool}"
+    )
   endforeach()
 
   add_custom_target("${_archive_target_name}" DEPENDS ${_archive_files})


### PR DESCRIPTION
Functional changes:

* Artifact archives now always write their manifest first (which for a tar file is important) and preserve the artifact directory structure (archives were being flattened as I hadn't fully thought through the case).
* The `artifact-flatten` command can now operate on exploded artifact directories or artifact archives.
* Target neutral artifacts are now named syntactically like their targetful counterparts but with a "_generic" suffix (e.g. "foo_dev_gfx100" vs "bar_dev_generic"). When working on Python packaging, I found myself regretting that these were syntactically different, as it made pattern matching harder.
* While some of this might be possible with just creative use of `tar` and friends, in my early experience having tried that, there are all kinds of corners with respect to attribute and symlink preservation when I tried to use other tools. I still think this tool is paying for itself because it is platform independent and doesn't have the preservation issues that were silently infecting some other attempts. It also works with trees of hardlinks, which is pretty important for performance of the build.

Additional cleanups:

* Removes THEROCK_ARTIFACT_ARCHIVE_TYPES: they are always .tar.xz now. This takes out some sketchy zip file handling too, which wasn't working out (zip is a very bad format for this and the numbers were terrible).
* Adds a unit test for fileset_tool.py. It doesn't have full coverage of everything yet, but tests the artifact->archive->flatten and round trip paths.
* Removes the configurable `--manifest` in favor of always generating in a fixed way.