### PR TITLE
Update docs and scripts after repo to submodules migration.

### DIFF
--- a/.github/workflows/build_windows_packages.yml
+++ b/.github/workflows/build_windows_packages.yml
@@ -40,9 +40,6 @@ jobs:
           echo  "BUILD_DIR_BASH=$bashBuildDir" >> $env:GITHUB_ENV
           Write-Host "Converted Build Directory For Bash: $bashBuildDir"
 
-      - name: Enabling git symlinks
-        run: git config --global core.symlinks true
-
       - name: "Checking out repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
@@ -77,13 +74,8 @@ jobs:
           restore-keys: |
             windows-build-packages-v2-
 
-      - name: Install Certs
-        run: python -m pip install certifi
-
       - name: Fetch sources
         run: |
-          # Sets an env variable to ensure urllib uses the certifi CA bundle in fetch_sources.py.
-          export SSL_CERT_FILE=$(python3 -m certifi)
           python ./build_tools/fetch_sources.py --jobs 12
 
       - name: Configure MSVC

--- a/README.md
+++ b/README.md
@@ -21,14 +21,17 @@ pip install CppHeaderParser==2.7.4 meson==1.7.0
 Dev tools:
 
 ```
-sudo apt install gfortran repo git-lfs ninja-build cmake g++ pkg-config xxd libgtest-dev
+sudo apt install gfortran git-lfs ninja-build cmake g++ pkg-config xxd libgtest-dev
 ```
 
+## On Windows
+
+> [!WARNING]
+> Windows support is still early in development. Not all subprojects or packages build for Windows yet.
+
+See [windows_support.md](./docs/development/windows_support.md).
+
 # Checkout Sources
-
-We want ROCm sources checked out into the sources/ directory or if you check it out elsewhere create a symlink called `ln -s /path/to/rocm sources`
-
-## Via script
 
 ```
 python ./build_tools/fetch_sources.py

--- a/build_tools/fetch_sources.py
+++ b/build_tools/fetch_sources.py
@@ -4,18 +4,14 @@
 # the CI uses to get to a clean state.
 
 import argparse
-import os
 from pathlib import Path
 import platform
 import shlex
-import shutil
 import subprocess
 import sys
-import urllib.request
 
 THIS_SCRIPT_DIR = Path(__file__).resolve().parent
 THEROCK_DIR = THIS_SCRIPT_DIR.parent
-DEFAULT_SOURCES_DIR = THEROCK_DIR / "sources"
 PATCHES_DIR = THEROCK_DIR / "patches"
 
 

--- a/docs/development/windows_support.md
+++ b/docs/development/windows_support.md
@@ -71,7 +71,11 @@ These instructions mostly mirror the instructions in the root
   terminal application. Some developers report good experiences with
   [Windows Terminal](https://learn.microsoft.com/en-us/windows/terminal/)
   and [Cmder](https://cmder.app/).
-* Symlink support must be enabled.
+* A Dev Drive is recommended, due to how many source and build files are used.
+  See the
+  [Set up a Dev Drive on Windows 11](https://learn.microsoft.com/en-us/windows/dev-drive/)
+  article for setup instructions.
+* Symlink support is recommended.
 
   Test if symlinks work from cmd:
 
@@ -93,23 +97,19 @@ These instructions mostly mirror the instructions in the root
   * https://portal.perforce.com/s/article/3472
   * https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/create-symbolic-links
   * https://stackoverflow.com/a/59761201
-* A Dev Drive is recommended, due to how many source and build files are used.
-  See the
-  [Set up a Dev Drive on Windows 11](https://learn.microsoft.com/en-us/windows/dev-drive/)
-  article for setup instructions.
 
 #### Install tools
 
 You will need:
 
 * Git: https://git-scm.com/downloads
-  * Also enable symlinks with `git config --global core.symlinks true`
+  * Suggested: enable symlinks with `git config --global core.symlinks true`
 * CMake: https://cmake.org/download/
 * Ninja: https://ninja-build.org/
 * (Optional) ccache: https://ccache.dev/, or sccache:
   https://github.com/mozilla/sccache
 * Python: https://www.python.org/downloads/ (3.11+ recommended)
-* A compiler like MSVC from https://visualstudio.microsoft.com/downloads/
+* The MSVC compiler from https://visualstudio.microsoft.com/downloads/
   (typically from either Visual Studio or the Build Tools for Visual Studio),
   including these components:
   * MSVC
@@ -128,32 +128,18 @@ You will need:
 > https://github.com/chocolatey/choco
 >
 > ```
+> choco install git
 > choco install cmake
 > choco install ninja
 > choco install ccache
 > choco install sccache
+> choco install python
 > ```
 
 ### Clone and fetch sources
 
 ```bash
 git clone https://github.com/nod-ai/TheRock.git
-```
-
-Check that symlinks were created:
-
-```bash
-stat base/rocm-core
-  File: base/rocm-core -> ../sources/rocm-core
-  Size: 20              Blocks: 0          IO Block: 65536  symbolic link
-```
-
-If symlinks were not created, follow the instructions at
-https://stackoverflow.com/a/59761201.
-
-Next, fetch sources:
-
-```bash
 python ./build_tools/fetch_sources.py
 ```
 


### PR DESCRIPTION
Follow-up to https://github.com/nod-ai/TheRock/pull/128.

* Drop some references to 'repo' and the 'sources/' directory
* Change Windows instructions from requiring symlinks to just recommending them
* Drop repo-specific configuration from Windows workflow