### PR TITLE
Add *.venv to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 install/
 sources/
 .vscode/
+*.venv


### PR DESCRIPTION
This helps keep dependencies isolated, especially when build instructions recommend installing packages: https://github.com/nod-ai/TheRock/blob/766eca85b45e0b532ea50bd561f2fb1f8f1d9726/README.md?plain=1#L13-L17 So far the Windows build is looking like it will also need the `jinja2` and `ruamel.yaml` Python packages.

I configure my CMake builds to use a venv, specifically from VSCode with this setting:

```json
    "settings": {
        "cmake.configureArgs": [
            "-DPython3_EXECUTABLE=${workspaceFolder}/.venv/Scripts/python",
```