### PR TITLE
Fix Python 3.10 issue

### DIFF
--- a/build_tools/patch_linux_so.py
+++ b/build_tools/patch_linux_so.py
@@ -67,7 +67,7 @@ def add_prefix(args: argparse.Namespace):
 
         # Remove old links.
         for orig_path in orig_paths:
-            if orig_path.exists(follow_symlinks=False):
+            if orig_path.is_symlink():
                 print(f"Removing original link: {orig_path}")
                 orig_path.unlink()
 


### PR DESCRIPTION
The `follow_symlinks` parameter was introduced with Python 3.12. Instead of checking with `exists()`, `is_symlink()` can be used as the script aims to explicitly remove old links at this stage.

Fixes #135