### PR TITLE
Fixing more python 3.10 issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ requires some additional development tools, which are included below.
 ## Common
 
 ```
-pip install CppHeaderParser==2.7.4 meson==1.7.0
+pip install CppHeaderParser==2.7.4 meson==1.7.0 toml==0.10.2
 ```
 
 ## On Ubuntu

--- a/build_tools/_therock_utils/pattern_match.py
+++ b/build_tools/_therock_utils/pattern_match.py
@@ -123,7 +123,7 @@ class PatternMatcher:
                     destpath.mkdir(parents=True, exist_ok=True)
                 elif direntry.is_symlink():
                     # Symlink.
-                    if not remove_dest and destpath.exists(follow_symlinks=False):
+                    if not remove_dest and destpath.is_symlink():
                         os.unlink(destpath)
                     targetpath = os.readlink(direntry.path)
                     if verbose:
@@ -136,7 +136,7 @@ class PatternMatcher:
                     os.symlink(targetpath, destpath)
                 else:
                     # Regular file.
-                    if not remove_dest and destpath.exists(follow_symlinks=False):
+                    if not remove_dest and destpath.is_symlink():
                         os.unlink(destpath)
                     destpath.parent.mkdir(parents=True, exist_ok=True)
                     linked_file = False

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -312,11 +312,13 @@ def _dup_list_or_str(v: list[str] | str) -> list[str]:
 def load_toml_file(p: Path):
     try:
         import tomllib
+
         with open(p, "rb") as f:
             return tomllib.load(f)
     except ModuleNotFoundError:
         # Python <= 3.10 compatibility (requires install of 'toml' package)
         import toml as tomllib
+
         return tomllib.load(p)
 
 

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -312,10 +312,12 @@ def _dup_list_or_str(v: list[str] | str) -> list[str]:
 def load_toml_file(p: Path):
     try:
         import tomllib
+        with open(p, "rb") as f:
+            return tomllib.load(f)
     except ModuleNotFoundError:
         # Python <= 3.10 compatibility (requires install of 'toml' package)
         import toml as tomllib
-    return tomllib.load(p)
+        return tomllib.load(p)
 
 
 def main(cl_args: list[str]):

--- a/build_tools/fileset_tool.py
+++ b/build_tools/fileset_tool.py
@@ -315,8 +315,7 @@ def load_toml_file(p: Path):
     except ModuleNotFoundError:
         # Python <= 3.10 compatibility (requires install of 'toml' package)
         import toml as tomllib
-    with open(p, "rb") as f:
-        return tomllib.load(f)
+    return tomllib.load(p)
 
 
 def main(cl_args: list[str]):


### PR DESCRIPTION
Found this while trying to setup TheRock

The [toml loads (python <= 3.10)](https://github.com/uiri/toml?tab=readme-ov-file#api-reference) handles file reading directly from the file. 

The [tomllib loads python >= 3.11](https://docs.python.org/3/library/tomllib.html#tomllib.load) requires `open(p, "rb")`

Fixing `.exists(follow_symlinks=False)` issue similar to here: https://github.com/nod-ai/TheRock/pull/137/files